### PR TITLE
Single source of truth for fonts

### DIFF
--- a/build-reset.js
+++ b/build-reset.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const less = require('less');
+const fonts = require('./fonts');
+
+less
+  .render(fs.readFileSync('./reset.less').toString(), {
+    modifyVars: {
+      fontBase: fonts.base,
+      fontCode: fonts.code
+    }
+  })
+  .then(output => {
+    fs.writeFileSync('reset.css', output.css);
+  });

--- a/fonts.js
+++ b/fonts.js
@@ -1,0 +1,4 @@
+module.exports = {
+  base: "'Source Sans Pro', sans-serif",
+  code: "'Source Code Pro', monospace"
+};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 const colors = require('./colors');
+const fonts = require('./fonts');
 
 exports.colors = colors;
+exports.fonts = fonts;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "lessc reset.less reset.css",
+    "prepare": "node build-reset.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/reset.less
+++ b/reset.less
@@ -10,9 +10,9 @@ html {
 }
 
 body {
-  font-family: 'Source Sans Pro', Helvetica, sans-serif;
+  font-family: @fontBase;
 }
 
 pre, code {
-  font-family: 'Source Code Pro', monospace;
+  font-family: @fontCode;
 }

--- a/stories/theme.js
+++ b/stories/theme.js
@@ -1,5 +1,6 @@
 import colors from '../colors';
-import { create } from '@storybook/theming';
+import fonts from '../fonts';
+import {create} from '@storybook/theming';
 
 export default create({
   base: colors.silver.light,
@@ -14,8 +15,8 @@ export default create({
   appBorderRadius: 4,
 
   // Typography
-  fontBase: '"Source Sans Pro", sans-serif',
-  fontCode: '"Source Code Pro", monospace',
+  fontBase: fonts.base,
+  fontCode: fonts.code,
 
   // Text colors
   textColor: colors.black.base,


### PR DESCRIPTION
This branch shares our `font-family` css rules between the stylesheet reset and storybook config. It also exports a `fonts` object with these values:

```js
{
  base: "'Source Sans Pro', sans-serif",
  code: "'Source Code Pro', monospace"
}
```

This could be useful when you need to programatically override font styles in our apps. For example, overriding the default font on a third-party code highlighting library.