### PR TITLE
Partial proposed changes to AP-543: Create buttons

### DIFF
--- a/src/Button.story.tsx
+++ b/src/Button.story.tsx
@@ -142,9 +142,9 @@ storiesOf("Space Kit", module)
       >
         <VerticalButtonGroup title="Example 1">
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -159,9 +159,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -176,9 +176,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
       </DemoSection>
@@ -189,9 +189,9 @@ storiesOf("Space Kit", module)
       >
         <VerticalButtonGroup title="Secondary">
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -202,9 +202,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -221,12 +221,12 @@ storiesOf("Space Kit", module)
           <React.Fragment>
             <Button
               css={{ marginRight: 6 }}
-              forceHoverState
+              data-force-hover-state="true"
               icon={iconElement}
             />
             <Button
               css={{ marginLeft: 6 }}
-              forceHoverState
+              data-force-hover-state="true"
               fab
               icon={iconElement}
             />
@@ -234,12 +234,12 @@ storiesOf("Space Kit", module)
           <React.Fragment>
             <Button
               css={{ marginRight: 6 }}
-              forceActiveState
+              data-force-active-state="true"
               icon={iconElement}
             />
             <Button
               css={{ marginLeft: 6 }}
-              forceActiveState
+              data-force-active-state="true"
               fab
               icon={iconElement}
             />
@@ -247,12 +247,12 @@ storiesOf("Space Kit", module)
           <React.Fragment>
             <Button
               css={{ marginRight: 6 }}
-              forceFocusState
+              data-force-focus-state="true"
               icon={iconElement}
             />
             <Button
               css={{ marginLeft: 6 }}
-              forceFocusState
+              data-force-focus-state="true"
               fab
               icon={iconElement}
             />
@@ -282,9 +282,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -302,9 +302,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
 
@@ -322,9 +322,9 @@ storiesOf("Space Kit", module)
           }}
         >
           <Button>Rest</Button>
-          <Button forceHoverState>Hover</Button>
-          <Button forceActiveState>Active</Button>
-          <Button forceFocusState>Focused</Button>
+          <Button data-force-hover-state="true">Hover</Button>
+          <Button data-force-active-state="true">Active</Button>
+          <Button data-force-focus-state="true">Focused</Button>
           <Button disabled>Disabled</Button>
         </VerticalButtonGroup>
       </DemoSection>

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -129,7 +129,7 @@ export const Button: React.FC<Props> = ({
     // The `box-shadow` property is copied directly from Zeplin
     boxShadow:
       "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)",
-    outline: 0,
+    outline: 0
   };
 
   return (
@@ -139,84 +139,89 @@ export const Button: React.FC<Props> = ({
       {...!disabled && forceActiveState && { "data-force-active-state": true }}
       {...!disabled && forceFocusState && { "data-force-focus-state": true }}
       {...!disabled && forceHoverState && { "data-force-hover-state": true }}
-      css={{
-        "&[disabled]": {
-          backgroundColor: colors.silver.dark,
-          color: colors.grey.light,
-
-          // We need to also set the `:hover` on `:disabled` so it has a higher
-          // specificity than any `:hover` classes passed in. This also means
-          // that both of these need to be overriden if we want to use a custom
-          // disabled color.
-          ":hover": {
+      css={[
+        {
+          "&[disabled]": {
             backgroundColor: colors.silver.dark,
             color: colors.grey.light,
-          },
+
+            // We need to also set the `:hover` on `:disabled` so it has a higher
+            // specificity than any `:hover` classes passed in. This also means
+            // that both of these need to be overriden if we want to use a custom
+            // disabled color.
+            ":hover": {
+              backgroundColor: colors.silver.dark,
+              color: colors.grey.light
+            }
+          }
         },
 
-        ...(variant === "simple" && { backgroundColor: "transparent" }),
+        variant === "simple" && { backgroundColor: "transparent" },
+        {
+          borderRadius: fab ? "100%" : 4,
 
-        borderRadius: fab ? "100%" : 4,
+          borderWidth: 0,
+          ...(variant === "normal" && {
+            boxShadow:
+              "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)"
+          }),
 
-        borderWidth: 0,
-        ...(variant === "normal" && {
-          boxShadow:
-            "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-        }),
-
-        minWidth: iconOnly
-          ? size === "small"
-            ? 28
+          minWidth: iconOnly
+            ? size === "small"
+              ? 28
+              : size === "large"
+              ? 42
+              : 36
+            : size === "small"
+            ? 76
             : size === "large"
-            ? 42
-            : 36
-          : size === "small"
-          ? 76
-          : size === "large"
-          ? 112
-          : 100,
+            ? 112
+            : 100,
 
-        padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
-        ...(size === "small"
-          ? base.small
-          : size === "large"
-          ? base.large
-          : base.base),
-
-        ...(!disabled && {
+          padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7
+        },
+        {
+          ...(size === "small"
+            ? base.small
+            : size === "large"
+            ? base.large
+            : base.base)
+        },
+        !disabled && {
           ":hover, &[data-force-hover-state]": {
             backgroundColor: colors.silver.base,
             cursor: "pointer",
             ...(variant === "normal" && {
               // The `box-shadow` property is copied directly from Zeplin
               boxShadow:
-                "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-            }),
-          },
-        }),
+                "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)"
+            })
+          }
+        },
+        {
+          fontWeight: 600,
 
-        fontWeight: 600,
+          // Disable the outline because we're setting a custom `:active` style
+          outline: 0,
 
-        // Disable the outline because we're setting a custom `:active` style
-        outline: 0,
-
-        ":focus, &[data-force-focus-state]": {
-          // The `box-shadow` property is copied directly from Zeplin
-          boxShadow:
-            "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+          ":focus, &[data-force-focus-state]": {
+            // The `box-shadow` property is copied directly from Zeplin
+            boxShadow:
+              "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)"
+          }
         },
 
         // This must come after `:focus` or the `:focus` state will override `:active`
-        ...(!disabled && forceActiveState
+        !disabled && forceActiveState
           ? activeProperties
-          : { ":active": activeProperties }),
-      }}
+          : { ":active": activeProperties }
+      ]}
     >
       <div
         css={{
           alignItems: "center",
           display: "flex",
-          justifyContent: "center",
+          justifyContent: "center"
         }}
       >
         {icon && (
@@ -225,7 +230,7 @@ export const Button: React.FC<Props> = ({
               display: "inline-block",
               height: iconSize,
               margin: iconOnly ? "3px 0" : "0 4px 0",
-              width: iconSize,
+              width: iconSize
             }}
           >
             {icon}

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -126,15 +126,20 @@ export const Button: React.FC<Props> = ({
             ? 112
             : 100,
 
-          padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7
-        },
-        {
+          padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
+
           ...(size === "small"
             ? base.small
             : size === "large"
             ? base.large
-            : base.base)
+            : base.base),
+
+          fontWeight: 600,
+          // Disable the outline because we're setting a custom `:active` style
+          outline: 0,
         },
+
+        // This must come after `:focus` or the `:focus` state will override `:active`
         !disabled && {
           ":hover, &[data-force-hover-state]": {
             backgroundColor: colors.silver.base,
@@ -144,23 +149,12 @@ export const Button: React.FC<Props> = ({
               boxShadow:
                 "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)"
             })
-          }
-        },
-        {
-          fontWeight: 600,
-
-          // Disable the outline because we're setting a custom `:active` style
-          outline: 0,
-
+          },
           ":focus, &[data-force-focus-state]": {
             // The `box-shadow` property is copied directly from Zeplin
             boxShadow:
               "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)"
-          }
-        },
-
-        // This must come after `:focus` or the `:focus` state will override `:active`
-        !disabled && {
+          },
           "&:active, &[data-force-active-state]": {
             // The `box-shadow` property is copied directly from Zeplin
             boxShadow: "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)",

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -26,33 +26,6 @@ interface Props
   fab?: boolean;
 
   /**
-   * Force the button to be in the active state.
-   *
-   * Useful for Storybook
-   *
-   * @ignore
-   */
-  forceActiveState?: boolean;
-
-  /**
-   * Force the button to be in the focus state.
-   *
-   * Useful for Storybook
-   *
-   * @ignore
-   */
-  forceFocusState?: boolean;
-
-  /**
-   * Force the button to be in the hover state.
-   *
-   * Useful for Storybook
-   *
-   * @ignore
-   */
-  forceHoverState?: boolean;
-
-  /**
    * Either an icon to show to the left of the button text, or on it's own
    */
   icon?: React.ReactElement;
@@ -88,9 +61,6 @@ export const Button: React.FC<Props> = ({
   children,
   disabled = false,
   fab = false,
-  forceActiveState = false,
-  forceFocusState = false,
-  forceHoverState = false,
   icon,
   size = "default",
   variant = "normal",
@@ -113,32 +83,10 @@ export const Button: React.FC<Props> = ({
     }
   }
 
-  if (forceActiveState && forceHoverState) {
-    throw new TypeError(
-      "Do not force multiple properties at once, you will get indeterminiate behavior"
-    );
-  }
-
-  /**
-   * Properties applied to for an active state.
-   *
-   * We store this so we can use it either in an `:active` style or when
-   * `forceActiveState` is set.
-   */
-  const activeProperties = {
-    // The `box-shadow` property is copied directly from Zeplin
-    boxShadow:
-      "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)",
-    outline: 0
-  };
-
   return (
     <button
       {...otherProps}
       disabled={disabled}
-      {...!disabled && forceActiveState && { "data-force-active-state": true }}
-      {...!disabled && forceFocusState && { "data-force-focus-state": true }}
-      {...!disabled && forceHoverState && { "data-force-hover-state": true }}
       css={[
         {
           "&[disabled]": {
@@ -212,9 +160,13 @@ export const Button: React.FC<Props> = ({
         },
 
         // This must come after `:focus` or the `:focus` state will override `:active`
-        !disabled && forceActiveState
-          ? activeProperties
-          : { ":active": activeProperties }
+        !disabled && {
+          "&:active, &[data-force-active-state]": {
+            // The `box-shadow` property is copied directly from Zeplin
+            boxShadow: "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)",
+            outline: 0,
+          }
+        },
       ]}
     >
       <div


### PR DESCRIPTION
This PR removes the `forceActiveState`, `forceHoverState`, and `forceFocusState` props from `<Button/>` 

There is value in being able to snapshot different visual states for regression snapshots, this switches to directly use and require the data attributes @justinanastos already uses in the component (set via the removed props). The difference is we no-longer expose the props publicly, i.e. no auto-completion when using the component (which imo is as it should be, I wouldn't want to see props I shouldn't use in the auto-completion list)

Another minor change is to take advantage of how the `css` prop accepts arrays, so we don't have to spread conditional styles into one object (emotion handles merging for us in the expected order (same as Object.assign)), less `...` syntax noise    

I think there still could be value in exposing a boolean `active` prop (out of scope of the initial component), but that's probably the only one where it makes sense to publicly force a state   

cc @timbotnik @trevorblades @mayakoneval 