### PR TITLE
AP-543 Allow custom emotion css injection point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ tsconfig.tsbuildinfo
 
 # Typography
 /typography
+
+# EmotionWrapper
+/EmotionWrapper.*

--- a/README.md
+++ b/README.md
@@ -7,21 +7,22 @@
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Installation](#Installation)
-- [Usage](#Usage)
-- [Exports](#Exports)
-  - [Stylesheet reset](#Stylesheet-reset)
-  - [Colors](#Colors)
-  - [Icons](#Icons)
-  - [Typography](#Typography)
-  - [Buttons](#Buttons)
-- [Developing Space Kit](#Developing-Space-Kit)
-  - [Icons](#Icons-1)
-  - [TypeScript](#TypeScript)
-  - [Storybook](#Storybook)
-- [Releasing](#Releasing)
-  - [Beta Releases](#Beta-Releases)
-- [Resources](#Resources)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Exports](#exports)
+  - [Emotion](#emotion)
+  - [Stylesheet reset](#stylesheet-reset)
+  - [Colors](#colors)
+  - [Icons](#icons)
+  - [Typography](#typography)
+  - [Buttons](#buttons)
+- [Developing Space Kit](#developing-space-kit)
+  - [Icons](#icons-1)
+  - [TypeScript](#typescript)
+  - [Storybook](#storybook)
+- [Releasing](#releasing)
+  - [Beta Releases](#beta-releases)
+- [Resources](#resources)
 
 ## Installation
 
@@ -54,9 +55,13 @@ function MyComponent() {
 
 ## Exports
 
-- [Stylesheet reset](#stylesheet-reset)
-- [Colors](#colors)
-- [Icons](#icons)
+### Emotion
+
+Some components are styled with [emotion](https://emotion.sh) under the hood; emotion appends `<style>` tags to your `<head>` element at runtime. This may cause emotions's styles to be included _after_ your project's styules, preventing you from using your own classes to override emotion's. To get around this, add the following element where you want the emotion styles to be injected. If you don't include this, emotion's default behavior will be followed.
+
+```html
+<style id="emotionStyleContainer"></style>
+```
 
 ### Stylesheet reset
 

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -2,6 +2,7 @@
 import * as colors from "./colors";
 import { base } from "./typography";
 import { jsx } from "@emotion/core";
+import { EmotionWrapper } from "./EmotionWrapper";
 
 // Types that could use some improvement:
 // * Don't allow `children` and `icon` to be missing
@@ -89,111 +90,113 @@ export const Button: React.FC<Props> = ({
   }
 
   return (
-    <button
-      {...otherProps}
-      disabled={disabled}
-      css={[
-        {
-          "&[disabled]": {
-            backgroundColor: colors.silver.dark,
-            color: colors.grey.light,
-
-            // We need to also set the `:hover` on `:disabled` so it has a higher
-            // specificity than any `:hover` classes passed in. This also means
-            // that both of these need to be overriden if we want to use a custom
-            // disabled color.
-            ":hover": {
+    <EmotionWrapper>
+      <button
+        {...otherProps}
+        disabled={disabled}
+        css={[
+          {
+            "&[disabled]": {
               backgroundColor: colors.silver.dark,
               color: colors.grey.light,
+
+              // We need to also set the `:hover` on `:disabled` so it has a higher
+              // specificity than any `:hover` classes passed in. This also means
+              // that both of these need to be overriden if we want to use a custom
+              // disabled color.
+              ":hover": {
+                backgroundColor: colors.silver.dark,
+                color: colors.grey.light,
+              },
             },
           },
-        },
 
-        {
-          backgroundColor:
-            feel === "raised" ? colors.silver.light : "transparent",
+          {
+            backgroundColor:
+              feel === "raised" ? colors.silver.light : "transparent",
 
-          borderRadius: variant === "fab" ? "100%" : 4,
+            borderRadius: variant === "fab" ? "100%" : 4,
 
-          borderWidth: 0,
-          ...(feel === "raised" && {
-            boxShadow:
-              "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-          }),
-
-          minWidth: iconOnly
-            ? size === "small"
-              ? 28
-              : size === "large"
-              ? 42
-              : 36
-            : size === "small"
-            ? 76
-            : size === "large"
-            ? 112
-            : 100,
-
-          padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
-
-          ...(size === "small"
-            ? base.small
-            : size === "large"
-            ? base.large
-            : base.base),
-
-          fontWeight: 600,
-
-          // Disable the outline because we're setting a custom `:active` style
-          outline: 0,
-        },
-
-        !disabled && {
-          ":hover, &[data-force-hover-state]": {
-            backgroundColor: colors.silver.base,
-            cursor: "pointer",
+            borderWidth: 0,
             ...(feel === "raised" && {
+              boxShadow:
+                "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+            }),
+
+            minWidth: iconOnly
+              ? size === "small"
+                ? 28
+                : size === "large"
+                ? 42
+                : 36
+              : size === "small"
+              ? 76
+              : size === "large"
+              ? 112
+              : 100,
+
+            padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
+
+            ...(size === "small"
+              ? base.small
+              : size === "large"
+              ? base.large
+              : base.base),
+
+            fontWeight: 600,
+
+            // Disable the outline because we're setting a custom `:active` style
+            outline: 0,
+          },
+
+          !disabled && {
+            ":hover, &[data-force-hover-state]": {
+              backgroundColor: colors.silver.base,
+              cursor: "pointer",
+              ...(feel === "raised" && {
+                // The `box-shadow` property is copied directly from Zeplin
+                boxShadow:
+                  "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+              }),
+            },
+            ":focus, &[data-force-focus-state]": {
               // The `box-shadow` property is copied directly from Zeplin
               boxShadow:
-                "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-            }),
+                "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+            },
+            "&:active, &[data-force-active-state]": {
+              // The `box-shadow` property is copied directly from Zeplin
+              boxShadow:
+                feel === "raised"
+                  ? "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)"
+                  : "none",
+              outline: "0",
+            },
           },
-          ":focus, &[data-force-focus-state]": {
-            // The `box-shadow` property is copied directly from Zeplin
-            boxShadow:
-              "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-          },
-          "&:active, &[data-force-active-state]": {
-            // The `box-shadow` property is copied directly from Zeplin
-            boxShadow:
-              feel === "raised"
-                ? "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)"
-                : "none",
-            outline: "0",
-          },
-        },
-      ]}
-    >
-      <div
-        css={{
-          alignItems: "center",
-          display: "flex",
-          justifyContent: "center",
-        }}
+        ]}
       >
-        {icon && (
-          <span
-            css={{
-              display: "inline-block",
-              height: iconSize,
-              margin: iconOnly ? "3px 0" : "0 4px 0",
-              width: iconSize,
-            }}
-          >
-            {icon}
-          </span>
-        )}
-        {children}
-      </div>
-    </button>
+        <div
+          css={{
+            alignItems: "center",
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          {icon && (
+            <span
+              css={{
+                display: "inline-block",
+                height: iconSize,
+                margin: iconOnly ? "3px 0" : "0 4px 0",
+                width: iconSize,
+              }}
+            >
+              {icon}
+            </span>
+          )}
+          {children}
+        </div>
+      </button>
+    </EmotionWrapper>
   );
 };

--- a/src/EmotionWrapper.tsx
+++ b/src/EmotionWrapper.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { CacheProvider } from "@emotion/core";
+import createCache from "@emotion/cache";
+
+// If there is an element with the `emotionStyleContainer` id, then use that to
+// put your emotion styles in. We need this to allow emotion styles to be
+// included before a bundle's css so we can override the styles with things like
+// tailwind.
+const emotionCache = createCache({
+  container:
+    document.querySelector<HTMLElement>("#emotionStyleContainer") || undefined,
+});
+
+/**
+ * Wrapper for any component that uses emotion
+ *
+ * This will wrap the component in a `CacheProvider` and use that to inject
+ * styles into #emotionStyleContainer. This is necessary to control the order of
+ * your bundle's css and where emotion injects it's css.
+ */
+export const EmotionWrapper: React.FC = ({ children }) => {
+  return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
+};


### PR DESCRIPTION
Emotion injects `<style>` elements at the end of your page's `<head>` at runtime. This can cause those styles to be placed after the page's `.css` assets, resulting in the `<style>` winning the tie-breaker of specificity. This will prevent consumers from overriding css properties with tailwind classes.

This PR adds the ability for users to specify where on the page the styles will be injected with a specific element that can be injected into the page.

Relates to [AP-543](https://golinks.io/j/AP-543)