### PR TITLE
remove EmotionWrapper from Button

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -2,7 +2,6 @@
 import * as colors from "./colors";
 import { base } from "./typography";
 import { jsx } from "@emotion/core";
-import { EmotionWrapper } from "./EmotionWrapper";
 
 // Types that could use some improvement:
 // * Don't allow `children` and `icon` to be missing
@@ -90,113 +89,111 @@ export const Button: React.FC<Props> = ({
   }
 
   return (
-    <EmotionWrapper>
-      <button
-        {...otherProps}
-        disabled={disabled}
-        css={[
-          {
-            "&[disabled]": {
+    <button
+      {...otherProps}
+      disabled={disabled}
+      css={[
+        {
+          "&[disabled]": {
+            backgroundColor: colors.silver.dark,
+            color: colors.grey.light,
+
+            // We need to also set the `:hover` on `:disabled` so it has a higher
+            // specificity than any `:hover` classes passed in. This also means
+            // that both of these need to be overriden if we want to use a custom
+            // disabled color.
+            ":hover": {
               backgroundColor: colors.silver.dark,
               color: colors.grey.light,
-
-              // We need to also set the `:hover` on `:disabled` so it has a higher
-              // specificity than any `:hover` classes passed in. This also means
-              // that both of these need to be overriden if we want to use a custom
-              // disabled color.
-              ":hover": {
-                backgroundColor: colors.silver.dark,
-                color: colors.grey.light,
-              },
             },
           },
+        },
 
-          {
-            backgroundColor:
-              feel === "raised" ? colors.silver.light : "transparent",
+        {
+          backgroundColor:
+            feel === "raised" ? colors.silver.light : "transparent",
 
-            borderRadius: variant === "fab" ? "100%" : 4,
+          borderRadius: variant === "fab" ? "100%" : 4,
 
-            borderWidth: 0,
+          borderWidth: 0,
+          ...(feel === "raised" && {
+            boxShadow:
+              "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+          }),
+
+          minWidth: iconOnly
+            ? size === "small"
+              ? 28
+              : size === "large"
+              ? 42
+              : 36
+            : size === "small"
+            ? 76
+            : size === "large"
+            ? 112
+            : 100,
+
+          padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
+
+          ...(size === "small"
+            ? base.small
+            : size === "large"
+            ? base.large
+            : base.base),
+
+          fontWeight: 600,
+
+          // Disable the outline because we're setting a custom `:active` style
+          outline: 0,
+        },
+
+        !disabled && {
+          ":hover, &[data-force-hover-state]": {
+            backgroundColor: colors.silver.base,
+            cursor: "pointer",
             ...(feel === "raised" && {
+              // The `box-shadow` property is copied directly from Zeplin
               boxShadow:
-                "0 1px 4px 0 rgba(18, 21, 26, 0.08), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
+                "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
             }),
-
-            minWidth: iconOnly
-              ? size === "small"
-                ? 28
-                : size === "large"
-                ? 42
-                : 36
-              : size === "small"
-              ? 76
-              : size === "large"
-              ? 112
-              : 100,
-
-            padding: size === "small" ? `5px 8px` : size === "large" ? 8 : 7,
-
-            ...(size === "small"
-              ? base.small
-              : size === "large"
-              ? base.large
-              : base.base),
-
-            fontWeight: 600,
-
-            // Disable the outline because we're setting a custom `:active` style
-            outline: 0,
           },
-
-          !disabled && {
-            ":hover, &[data-force-hover-state]": {
-              backgroundColor: colors.silver.base,
-              cursor: "pointer",
-              ...(feel === "raised" && {
-                // The `box-shadow` property is copied directly from Zeplin
-                boxShadow:
-                  "0 5px 10px 0 rgba(18, 21, 26, 0.12), inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-              }),
-            },
-            ":focus, &[data-force-focus-state]": {
-              // The `box-shadow` property is copied directly from Zeplin
-              boxShadow:
-                "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
-            },
-            "&:active, &[data-force-active-state]": {
-              // The `box-shadow` property is copied directly from Zeplin
-              boxShadow:
-                feel === "raised"
-                  ? "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)"
-                  : "none",
-              outline: "0",
-            },
+          ":focus, &[data-force-focus-state]": {
+            // The `box-shadow` property is copied directly from Zeplin
+            boxShadow:
+              "0 1px 4px 0 rgba(18, 21, 26, 0.08), 0 0 0 2px #bbdbff, inset 0 0 0 1px #2075d6, inset 0 -1px 0 0 rgba(18, 21, 26, 0.05)",
           },
-        ]}
+          "&:active, &[data-force-active-state]": {
+            // The `box-shadow` property is copied directly from Zeplin
+            boxShadow:
+              feel === "raised"
+                ? "inset 0 0 0 1px rgba(18, 21, 26, 0.2), inset 0 -1px 0 0 rgba(18, 21, 26, 0.05), inset 0 2px 2px 0 rgba(18, 21, 26, 0.12)"
+                : "none",
+            outline: "0",
+          },
+        },
+      ]}
+    >
+      <div
+        css={{
+          alignItems: "center",
+          display: "flex",
+          justifyContent: "center",
+        }}
       >
-        <div
-          css={{
-            alignItems: "center",
-            display: "flex",
-            justifyContent: "center",
-          }}
-        >
-          {icon && (
-            <span
-              css={{
-                display: "inline-block",
-                height: iconSize,
-                margin: iconOnly ? "3px 0" : "0 4px 0",
-                width: iconSize,
-              }}
-            >
-              {icon}
-            </span>
-          )}
-          {children}
-        </div>
-      </button>
-    </EmotionWrapper>
+        {icon && (
+          <span
+            css={{
+              display: "inline-block",
+              height: iconSize,
+              margin: iconOnly ? "3px 0" : "0 4px 0",
+              width: iconSize,
+            }}
+          >
+            {icon}
+          </span>
+        )}
+        {children}
+      </div>
+    </button>
   );
 };


### PR DESCRIPTION
Follow up to https://github.com/apollographql/space-kit/pull/23   
I didn't realize in that PR the `EmotionWrapper` which is essentially an alias around `CacheProvider` in the PR was added to wrap around Button. `CacheProvider` isn't meant to wrap around individual components (that'd be like wrapping an ApolloProvider around each Query component)

The only thing this PR does is to remove the `<EmotionWrapper>` wrapping around the contents of Button

Projects that need to specify where styles need to be injected (afaik just Engine for now) should either import EmotionWrapper (or CacheProvider) and use it next ApolloProvider (inside/outside doesn't quite matter)