### PR TITLE
Make Icon weight configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Move all `src` files to live in paths (#31)
 - Fix broken storybook (#39)
 - Remove top level Space Kit namespace in Storybook (#38)
+- Make Icon weight configurable (#33)
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8061,6 +8061,15 @@
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
       "dev": true
     },
+    "immutability-helper": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.0.1.tgz",
+      "integrity": "sha512-U92ROQQt7XkIwrdqCByUI118TQM1hXdKnRQpvKeA0HRyGSnJipu9IWHe4UD8zCN00O8UnQjQzPCgZ1CC3yBzHA==",
+      "dev": true,
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.1",
+    "immutability-helper": "^3.0.1",
     "less": "^3.9.0",
     "normalize.css": "^8.0.1",
     "npm-run-all": "^4.1.5",

--- a/src/icons/Icons.story.jsx
+++ b/src/icons/Icons.story.jsx
@@ -51,6 +51,8 @@ storiesOf("Icons", module)
   .addDecorator(withKnobs)
   .add("Catalog", () => {
     const color = select("Color", colorMap, colors.black.base);
+    const weight = select("Weight", ["normal", "heavy"], "normal");
+
     return (
       <Page
         title="Icons"
@@ -75,6 +77,7 @@ storiesOf("Icons", module)
                   )}
                 </div>
                 <Component
+                  weight={weight}
                   style={{
                     width: 20,
                     height: 20,

--- a/typings/svgr__core/index.d.ts
+++ b/typings/svgr__core/index.d.ts
@@ -1,4 +1,6 @@
 declare module "@svgr/core" {
+  import { JSXElement } from "@babel/types";
+
   export interface Config {
     /**
      * Specify a custom config file.
@@ -78,7 +80,7 @@ declare module "@svgr/core" {
         props: object;
         imports: any;
         exports: any;
-        jsx: any;
+        jsx: JSXElement;
       }
     ) => any;
 


### PR DESCRIPTION
First, this PR will look scary and that's ok.

When we generate the React files, we're given an AST of svgr's final output. We can then modify that to add or remove things. This will allow us to make the stroke width configurable and to set a style to prevent the size from causing the stroke width to change.

Take a look at the storybook story and see that it's now configurable with a weight!