### PR TITLE
Move from "Space Kit" to top-level namespacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Convert all remaining files to TypeScript (#27)
 - Move all `src` files to live in paths (#31)
 - Fix broken storybook (#39)
+- Remove top level Space Kit namespace in Storybook (#38)
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)
 

--- a/src/Button/Button.story.tsx
+++ b/src/Button/Button.story.tsx
@@ -112,13 +112,13 @@ const VerticalButtonGroup: React.FC<{
   </div>
 );
 
-storiesOf("Space Kit", module)
+storiesOf("Button", module)
   .addParameters({
     options: {
       showPanel: false,
     },
   })
-  .add("Button", () => (
+  .add("Catalog", () => (
     <div css={{ color: colors.black.base }}>
       <DemoSection
         title="Button Sizes"

--- a/src/Modal/Modal.story.tsx
+++ b/src/Modal/Modal.story.tsx
@@ -46,7 +46,7 @@ export function ModalStory({
   );
 }
 
-storiesOf("Space Kit/Modal", module)
+storiesOf("Modal", module)
   .add("interactive", () => (
     <div css={{ position: "absolute", left: 200 }}>
       <ModalStory

--- a/src/Table/Table.story.tsx
+++ b/src/Table/Table.story.tsx
@@ -47,9 +47,9 @@ const users: User[] = [
   },
 ];
 
-storiesOf("Space Kit", module)
+storiesOf("Table", module)
   .addDecorator(withKnobs)
-  .add("Table", () => (
+  .add("User Example", () => (
     <Table<User>
       keyOn="name"
       css={{ color: colors.black.base }}


### PR DESCRIPTION
As discussed in our steering meeting, we are agreed to not nest components under a "Spacekit" namespace.  Unfortunately I have not tested this as storybook is currently busted.