### PR TITLE
Card component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tsconfig.tsbuildinfo
 /fonts
 /icons
 /Modal
+/Card
 /shared
 /Table
 /typography

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Make Icon weight configurable (#33)
 - Edit Modal prop descriptions, fix margin top on children [#41](https://github.com/apollographql/space-kit/pull/41)
 - Export constant from `colors` instead of requiring `import * as colors` (#35)
-- Add Card component
 - Add Card component (#34)
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Make Icon weight configurable (#33)
 - Edit Modal prop descriptions, fix margin top on children [#41](https://github.com/apollographql/space-kit/pull/41)
 - Export constant from `colors` instead of requiring `import * as colors` (#35)
+- Add Card component
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Edit Modal prop descriptions, fix margin top on children [#41](https://github.com/apollographql/space-kit/pull/41)
 - Export constant from `colors` instead of requiring `import * as colors` (#35)
 - Add Card component
+- Add Card component (#34)
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)
 

--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -2,7 +2,7 @@
 import { jsx } from "@emotion/core";
 import { useState } from "react";
 import { storiesOf } from "@storybook/react";
-import { Card } from "./Card";
+import { Card, CardSection } from "./Card";
 import { Button } from "../Button";
 import * as colors from "../colors";
 
@@ -104,5 +104,40 @@ storiesOf("Card", module)
       }}
     >
       <CardWithDrawer />
+    </div>
+  ))
+  .add("multiple sections", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <Card
+        title="Card Title"
+        description="description goes here"
+        titleChildren={
+          <Button color={colors.red.base}>
+            <div css={{ color: colors.white }}>Click</div>
+          </Button>
+        }
+        forceNoChildPadding={true}
+      >
+        <CardSection
+          title="Members"
+          description="You have 7 members in your organization"
+        />
+        <CardSection
+          title="Members"
+          description="You have 7 members in your organization"
+          border={true}
+          titleChildren={
+            <Button color={colors.red.base}>
+              <div css={{ color: colors.white }}>Edit</div>
+            </Button>
+          }
+        />
+      </Card>
     </div>
   ));

--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -1,0 +1,108 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { useState } from "react";
+import { storiesOf } from "@storybook/react";
+import { Card } from "./Card";
+import { Button } from "../Button";
+import * as colors from "../colors";
+
+const CardWithDrawer = () => {
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+  return (
+    <Card
+      title="Card Title"
+      description="description goes here"
+      forceNoChildPadding={true}
+      titleChildren={
+        <Button
+          color={colors.red.base}
+          onClick={() => setDrawerOpen(!drawerOpen)}
+        >
+          <div css={{ color: colors.white }}>Click</div>
+        </Button>
+      }
+    >
+      {drawerOpen && (
+        <div
+          css={{
+            height: "2.5rem",
+            backgroundColor: colors.black.base,
+            color: colors.white,
+            padding: 20,
+          }}
+        >
+          card content
+        </div>
+      )}
+    </Card>
+  );
+};
+
+storiesOf("Card", module)
+  .add("default", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <Card title="Card Title" description="description goes here">
+        <div>card content</div>
+      </Card>
+    </div>
+  ))
+  .add("large", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <Card
+        size="large"
+        title="Card Title"
+        description="description goes here"
+        titleChildren={
+          <Button color={colors.red.base}>
+            <div css={{ color: colors.white }}>Click</div>
+          </Button>
+        }
+      >
+        <div>card content</div>
+      </Card>
+    </div>
+  ))
+  .add("with title children - button", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <Card
+        title="Card Title"
+        description="description goes here"
+        titleChildren={
+          <Button color={colors.red.base}>
+            <div css={{ color: colors.white }}>Click</div>
+          </Button>
+        }
+      >
+        <div>card content</div>
+      </Card>
+    </div>
+  ))
+  .add("force no child padding (use for drawers)", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <CardWithDrawer />
+    </div>
+  ));

--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -3,10 +3,21 @@ import { jsx } from "@emotion/core";
 import { storiesOf } from "@storybook/react";
 import { Card, CardSection, CardSeperator } from "./Card";
 import { Button } from "../Button";
-import * as colors from "../colors";
+import { colors } from "../colors";
 
 storiesOf("Card", module)
   .add("default", () => (
+    <div
+      css={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+      }}
+    >
+      <Card />
+    </div>
+  ))
+  .add("default, heading, description", () => (
     <div
       css={{
         backgroundColor: colors.silver.light,

--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -1,42 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { useState } from "react";
 import { storiesOf } from "@storybook/react";
-import { Card, CardSection } from "./Card";
+import { Card, CardSection, CardSeperator } from "./Card";
 import { Button } from "../Button";
 import * as colors from "../colors";
-
-const CardWithDrawer = () => {
-  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  return (
-    <Card
-      title="Card Title"
-      description="description goes here"
-      forceNoChildPadding={true}
-      titleChildren={
-        <Button
-          color={colors.red.base}
-          onClick={() => setDrawerOpen(!drawerOpen)}
-        >
-          <div css={{ color: colors.white }}>Click</div>
-        </Button>
-      }
-    >
-      {drawerOpen && (
-        <div
-          css={{
-            height: "2.5rem",
-            backgroundColor: colors.black.base,
-            color: colors.white,
-            padding: 20,
-          }}
-        >
-          card content
-        </div>
-      )}
-    </Card>
-  );
-};
 
 storiesOf("Card", module)
   .add("default", () => (
@@ -47,7 +14,7 @@ storiesOf("Card", module)
         height: "100vh",
       }}
     >
-      <Card title="Card Title" description="description goes here">
+      <Card heading="Card heading" description="description goes here">
         <div>card content</div>
       </Card>
     </div>
@@ -62,9 +29,9 @@ storiesOf("Card", module)
     >
       <Card
         size="large"
-        title="Card Title"
+        heading="Card heading"
         description="description goes here"
-        titleChildren={
+        actions={
           <Button color={colors.red.base}>
             <div css={{ color: colors.white }}>Click</div>
           </Button>
@@ -74,7 +41,7 @@ storiesOf("Card", module)
       </Card>
     </div>
   ))
-  .add("with title children - button", () => (
+  .add("with actions - button", () => (
     <div
       css={{
         backgroundColor: colors.silver.light,
@@ -83,9 +50,9 @@ storiesOf("Card", module)
       }}
     >
       <Card
-        title="Card Title"
-        description="description goes here"
-        titleChildren={
+        heading="Card heading"
+        description="description goes here. This could be a really long description like so. If its really long it should leave space for the title actions like this red button."
+        actions={
           <Button color={colors.red.base}>
             <div css={{ color: colors.white }}>Click</div>
           </Button>
@@ -93,17 +60,6 @@ storiesOf("Card", module)
       >
         <div>card content</div>
       </Card>
-    </div>
-  ))
-  .add("force no child padding (use for drawers)", () => (
-    <div
-      css={{
-        backgroundColor: colors.silver.light,
-        padding: "40px",
-        height: "100vh",
-      }}
-    >
-      <CardWithDrawer />
     </div>
   ))
   .add("multiple sections", () => (
@@ -115,24 +71,23 @@ storiesOf("Card", module)
       }}
     >
       <Card
-        title="Card Title"
-        description="description goes here"
-        titleChildren={
+        heading="Card heading"
+        description="Description"
+        actions={
           <Button color={colors.red.base}>
             <div css={{ color: colors.white }}>Click</div>
           </Button>
         }
-        forceNoChildPadding={true}
       >
         <CardSection
-          title="Members"
+          heading="Members"
           description="You have 7 members in your organization"
         />
+        <CardSeperator />
         <CardSection
-          title="Members"
+          heading="Members"
           description="You have 7 members in your organization"
-          border={true}
-          titleChildren={
+          actions={
             <Button color={colors.red.base}>
               <div css={{ color: colors.white }}>Edit</div>
             </Button>

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,42 +1,36 @@
 /** @jsx jsx */
-import * as colors from "../colors";
+import { colors } from "../colors";
 import { base } from "../typography";
 import { jsx } from "@emotion/core";
 import React from "react";
 import PropTypes from "prop-types";
 
-interface Props {
+interface Props
+  extends React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  > {
   /**
    * The content of the card,
    * appears below the title and description
    */
   children?: React.ReactNode;
-  /**
-   * the title of the card
-   */
-  title?: React.ReactNode;
-  /**
-   * extra class names
-   * applied to the outer most div
-   */
-  className?: string;
+
+  heading?: React.ReactNode;
+
   /**
    * the description for this card
    * appears in grey below the title
    */
   description?: React.ReactNode;
+
   /**
-   * titleChildren could be a button
+   * actions could be a button
    * or a tooltip or anything the card should display
    * aligned with the title on the right
    */
-  titleChildren?: React.ReactNode;
-  /**
-   * pass forceNoChildPadding={true} if your card will have hidden children
-   * for example, a card with a drawer will read as having children,
-   * but you don't want the padding associated with a child
-   */
-  forceNoChildPadding?: boolean;
+  actions?: React.ReactNode;
+
   /**
    * cards can be standard (18px text, larger padding)
    * or large (24px text, smaller padding)
@@ -46,9 +40,8 @@ interface Props {
 
 export const Card: React.FunctionComponent<Props> = ({
   children,
-  forceNoChildPadding,
-  title,
-  titleChildren,
+  heading,
+  actions,
   description,
   size,
   ...otherProps
@@ -59,100 +52,82 @@ export const Card: React.FunctionComponent<Props> = ({
       backgroundColor: colors.white,
       color: colors.black.base,
       boxShadow: `0 4px 8px 0 rgba(0, 0, 0, .04)`,
-      borderRadius: `0.5rem`,
+      borderStyle: "solid",
+      borderRadius: 8,
       borderWidth: 1,
       borderColor: colors.silver.dark,
       paddingLeft: 24,
       paddingRight: 24,
-      margin: "2rem",
       paddingTop: size === "large" ? 16 : 28,
       paddingBottom: size === "large" ? 16 : 28,
     }}
   >
-    <div
-      css={{
-        paddingBottom: -!!children && !forceNoChildPadding ? 24 : "",
-      }}
-    >
-      <div css={{ display: "flex" }}>
-        <div css={{ flex: "1 1 0%" }}>
-          <div css={{ display: "block" }}>
-            {title && (
-              <div
+    <div css={{ display: "flex" }}>
+      <div css={{ flex: "1 1 0%", marginRight: "auto" }}>
+        <div css={{ display: "block" }}>
+          {heading && (
+            <div
+              css={{
+                display: "flex",
+                color: colors.black.base,
+                ...(size === "large" ? base.xxlarge : base.large),
+              }}
+            >
+              <span
                 css={{
-                  display: "flex",
-                  color: colors.black.base,
-                  ...(size === "large" ? base.xxlarge : base.large),
+                  fontWeight: 600,
+                  flex: "1 1 0%",
+                  lineHeight: 1.5,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  paddingRight: 24,
                 }}
               >
-                <span
-                  css={{
-                    fontWeight: 600,
-                    flex: "1 1 0%",
-                    lineHeight: 1.5,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    paddingRight: 24,
-                  }}
-                >
-                  {title}
-                </span>
-              </div>
-            )}
-            {description && (
-              <div
-                css={{
-                  ...base.base,
-                  color: colors.grey.base,
-                  maxWidth: titleChildren ? "42rem" : "",
-                }}
-              >
-                {description}
-              </div>
-            )}
-          </div>
+                {heading}
+              </span>
+            </div>
+          )}
+          {description && (
+            <div
+              css={{
+                ...base.base,
+                color: colors.grey.base,
+                maxWidth: actions ? 650 : "",
+              }}
+            >
+              {description}
+            </div>
+          )}
         </div>
-        {titleChildren && (
-          <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
-        )}
       </div>
+      {actions && <div css={{ marginLeft: 16 }}>{actions}</div>}
     </div>
-    {children}
+    {children && <div css={{ paddingTop: 24 }}>{children} </div>}
   </div>
 );
 
 Card.propTypes = {
   children: PropTypes.node,
-  title: PropTypes.node,
-  className: PropTypes.string,
+  heading: PropTypes.node,
   description: PropTypes.node,
-  titleChildren: PropTypes.node,
-  forceNoChildPadding: PropTypes.bool,
+  actions: PropTypes.node,
   size: PropTypes.oneOf<Props["size"]>(["standard", "large"]),
 };
 
-interface SectionProps {
-  border?: boolean;
-}
-
-export const CardSection: React.FunctionComponent<Props & SectionProps> = ({
-  title,
+export const CardSection: React.FunctionComponent<Props> = ({
+  heading,
   description,
-  titleChildren,
-  border,
+  actions,
 }) => (
   <div
     css={{
       display: "flex",
-      paddingTop: 24,
-      border: border ? "1px" : "",
-      borderColor: colors.silver.base,
     }}
   >
-    <div css={{ flex: "1 1 0%" }}>
+    <div css={{ flex: "1 1 0%", marginRight: "auto" }}>
       <div css={{ display: "block" }}>
-        {title && (
+        {heading && (
           <div
             css={{
               display: "flex",
@@ -171,7 +146,7 @@ export const CardSection: React.FunctionComponent<Props & SectionProps> = ({
                 paddingRight: 24,
               }}
             >
-              {title}
+              {heading}
             </span>
           </div>
         )}
@@ -180,7 +155,7 @@ export const CardSection: React.FunctionComponent<Props & SectionProps> = ({
             css={{
               ...base.base,
               color: colors.grey.base,
-              maxWidth: titleChildren ? "42rem" : "",
+              maxWidth: actions ? 650 : "",
             }}
           >
             {description}
@@ -188,16 +163,24 @@ export const CardSection: React.FunctionComponent<Props & SectionProps> = ({
         )}
       </div>
     </div>
-    {titleChildren && (
-      <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
-    )}
+    {actions && <div css={{ marginLeft: 16 }}>{actions}</div>}
   </div>
 );
 
 CardSection.propTypes = {
-  title: PropTypes.node,
+  heading: PropTypes.node,
   description: PropTypes.node,
-  titleChildren: PropTypes.node,
-  forceNoChildPadding: PropTypes.bool,
-  border: PropTypes.bool,
+  actions: PropTypes.node,
 };
+
+export const CardSeperator: React.FunctionComponent = () => (
+  <hr
+    style={{
+      height: 1,
+      borderWidth: 0,
+      backgroundColor: colors.silver.dark,
+      marginTop: 24,
+      marginBottom: 24,
+    }}
+  />
+);

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -5,38 +5,27 @@ import { jsx } from "@emotion/core";
 import React from "react";
 import PropTypes from "prop-types";
 
-const descriptionMaxWidth = 650;
+const descriptionMaxWidth = 640;
 
-interface Props
+interface CardProps
   extends React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLDivElement>,
-    HTMLDivElement
-  > {
+      React.HTMLAttributes<HTMLDivElement>,
+      HTMLDivElement
+    >,
+    CardSectionProps {
   /**
    * The content of the card,
    * appears below the title and description
    */
   children?: React.ReactNode;
 
-  heading?: React.ReactNode;
-
   /**
-   * the description for this card
-   * appears in grey below the title
+   * large has bigger heading & smaller padding than standard
    */
-  description?: React.ReactNode;
-
-  /**
-   * actions could be a button
-   * or a tooltip or anything the card should display
-   * aligned with the title on the right
-   */
-  actions?: React.ReactNode;
-
   size?: "standard" | "large";
 }
 
-export const Card: React.FC<Props> = ({
+export const Card: React.FC<CardProps> = ({
   children,
   heading,
   actions,
@@ -114,10 +103,27 @@ Card.propTypes = {
   heading: PropTypes.node,
   description: PropTypes.node,
   actions: PropTypes.node,
-  size: PropTypes.oneOf<Props["size"]>(["standard", "large"]),
+  size: PropTypes.oneOf<CardProps["size"]>(["standard", "large"]),
 };
 
-export const CardSection: React.FC<Props> = ({
+interface CardSectionProps {
+  heading?: React.ReactNode;
+
+  /**
+   * the description for this card
+   * appears in grey below the title
+   */
+  description?: React.ReactNode;
+
+  /**
+   * actions could be a button
+   * or a tooltip or anything the card should display
+   * aligned with the title on the right
+   */
+  actions?: React.ReactNode;
+}
+
+export const CardSection: React.FC<CardSectionProps> = ({
   heading,
   description,
   actions,

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -6,12 +6,41 @@ import React from "react";
 import PropTypes from "prop-types";
 
 interface Props {
+  /**
+   * The content of the card,
+   * appears below the title and description
+   */
   children?: React.ReactNode;
+  /**
+   * the title of the card
+   */
   title?: React.ReactNode;
+  /**
+   * extra class names
+   * applied to the outer most div
+   */
   className?: string;
+  /**
+   * the description for this card
+   * appears in grey below the title
+   */
   description?: React.ReactNode;
+  /**
+   * titleChildren could be a button
+   * or a tooltip or anything the card should display
+   * aligned with the title on the right
+   */
   titleChildren?: React.ReactNode;
+  /**
+   * pass forceNoChildPadding={true} if your card will have hidden children
+   * for example, a card with a drawer will read as having children,
+   * but you don't want the padding associated with a child
+   */
   forceNoChildPadding?: boolean;
+  /**
+   * cards can be standard (18px text, larger padding)
+   * or large (24px text, smaller padding)
+   */
   size?: "standard" | "large";
 }
 

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -69,50 +69,54 @@ export const Card: React.FunctionComponent<Props> = ({
       paddingBottom: size === "large" ? 16 : 28,
     }}
   >
-    <div css={{ display: "flex" }}>
-      <div css={{ flex: "1 1 0%" }}>
-        <div css={{ display: "block" }}>
-          {title && (
-            <div
-              css={{
-                display: "flex",
-                color: colors.black.base,
-                ...(size === "large" ? base.xxlarge : base.large),
-              }}
-            >
-              <span
+    <div
+      css={{
+        paddingBottom: -!!children && !forceNoChildPadding ? 24 : "",
+      }}
+    >
+      <div css={{ display: "flex" }}>
+        <div css={{ flex: "1 1 0%" }}>
+          <div css={{ display: "block" }}>
+            {title && (
+              <div
                 css={{
-                  fontWeight: 600,
-                  flex: "1 1 0%",
-                  lineHeight: 1.5,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                  paddingRight: "1rem",
+                  display: "flex",
+                  color: colors.black.base,
+                  ...(size === "large" ? base.xxlarge : base.large),
                 }}
               >
-                {title}
-              </span>
-            </div>
-          )}
-          {description && (
-            <div
-              css={{
-                ...base.base,
-                color: colors.grey.base,
-                maxWidth: titleChildren ? "42rem" : "",
-                paddingBottom:
-                  !!children && !forceNoChildPadding ? "1.5rem" : "",
-              }}
-            >
-              {description}
-            </div>
-          )}
+                <span
+                  css={{
+                    fontWeight: 600,
+                    flex: "1 1 0%",
+                    lineHeight: 1.5,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    paddingRight: 24,
+                  }}
+                >
+                  {title}
+                </span>
+              </div>
+            )}
+            {description && (
+              <div
+                css={{
+                  ...base.base,
+                  color: colors.grey.base,
+                  maxWidth: titleChildren ? "42rem" : "",
+                }}
+              >
+                {description}
+              </div>
+            )}
+          </div>
         </div>
+        {titleChildren && (
+          <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
+        )}
       </div>
-      {titleChildren && (
-        <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
-      )}
     </div>
     {children}
   </div>
@@ -126,4 +130,74 @@ Card.propTypes = {
   titleChildren: PropTypes.node,
   forceNoChildPadding: PropTypes.bool,
   size: PropTypes.oneOf<Props["size"]>(["standard", "large"]),
+};
+
+interface SectionProps {
+  border?: boolean;
+}
+
+export const CardSection: React.FunctionComponent<Props & SectionProps> = ({
+  title,
+  description,
+  titleChildren,
+  border,
+}) => (
+  <div
+    css={{
+      display: "flex",
+      paddingTop: 24,
+      border: border ? "1px" : "",
+      borderColor: colors.silver.base,
+    }}
+  >
+    <div css={{ flex: "1 1 0%" }}>
+      <div css={{ display: "block" }}>
+        {title && (
+          <div
+            css={{
+              display: "flex",
+              color: colors.black.base,
+              ...base.base,
+            }}
+          >
+            <span
+              css={{
+                fontWeight: 600,
+                flex: "1 1 0%",
+                lineHeight: 1.5,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                paddingRight: 24,
+              }}
+            >
+              {title}
+            </span>
+          </div>
+        )}
+        {description && (
+          <div
+            css={{
+              ...base.base,
+              color: colors.grey.base,
+              maxWidth: titleChildren ? "42rem" : "",
+            }}
+          >
+            {description}
+          </div>
+        )}
+      </div>
+    </div>
+    {titleChildren && (
+      <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
+    )}
+  </div>
+);
+
+CardSection.propTypes = {
+  title: PropTypes.node,
+  description: PropTypes.node,
+  titleChildren: PropTypes.node,
+  forceNoChildPadding: PropTypes.bool,
+  border: PropTypes.bool,
 };

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,0 +1,100 @@
+/** @jsx jsx */
+import * as colors from "../colors";
+import { base } from "../typography";
+import { jsx } from "@emotion/core";
+import React from "react";
+import PropTypes from "prop-types";
+
+interface Props {
+  children?: React.ReactNode;
+  title?: React.ReactNode;
+  className?: string;
+  description?: React.ReactNode;
+  titleChildren?: React.ReactNode;
+  forceNoChildPadding?: boolean;
+  size?: "standard" | "large";
+}
+
+export const Card: React.FunctionComponent<Props> = ({
+  children,
+  forceNoChildPadding,
+  title,
+  titleChildren,
+  description,
+  size,
+  ...otherProps
+}) => (
+  <div
+    {...otherProps}
+    css={{
+      backgroundColor: colors.white,
+      color: colors.black.base,
+      boxShadow: `0 4px 8px 0 rgba(0, 0, 0, .04)`,
+      borderRadius: `0.5rem`,
+      borderWidth: 1,
+      borderColor: colors.silver.dark,
+      paddingLeft: 24,
+      paddingRight: 24,
+      margin: "2rem",
+      paddingTop: size === "large" ? 16 : 28,
+      paddingBottom: size === "large" ? 16 : 28,
+    }}
+  >
+    <div css={{ display: "flex" }}>
+      <div css={{ flex: "1 1 0%" }}>
+        <div css={{ display: "block" }}>
+          {title && (
+            <div
+              css={{
+                display: "flex",
+                color: colors.black.base,
+                ...(size === "large" ? base.xxlarge : base.large),
+              }}
+            >
+              <span
+                css={{
+                  fontWeight: 600,
+                  flex: "1 1 0%",
+                  lineHeight: 1.5,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  paddingRight: "1rem",
+                }}
+              >
+                {title}
+              </span>
+            </div>
+          )}
+          {description && (
+            <div
+              css={{
+                ...base.base,
+                color: colors.grey.base,
+                maxWidth: titleChildren ? "42rem" : "",
+                paddingBottom:
+                  !!children && !forceNoChildPadding ? "1.5rem" : "",
+              }}
+            >
+              {description}
+            </div>
+          )}
+        </div>
+      </div>
+      {titleChildren && (
+        <div css={{ flex: "none", marginLeft: "1rem" }}>{titleChildren}</div>
+      )}
+    </div>
+    {children}
+  </div>
+);
+
+Card.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.node,
+  className: PropTypes.string,
+  description: PropTypes.node,
+  titleChildren: PropTypes.node,
+  forceNoChildPadding: PropTypes.bool,
+  size: PropTypes.oneOf<Props["size"]>(["standard", "large"]),
+};

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -5,6 +5,8 @@ import { jsx } from "@emotion/core";
 import React from "react";
 import PropTypes from "prop-types";
 
+const descriptionMaxWidth = 650;
+
 interface Props
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
@@ -31,14 +33,10 @@ interface Props
    */
   actions?: React.ReactNode;
 
-  /**
-   * cards can be standard (18px text, larger padding)
-   * or large (24px text, smaller padding)
-   */
   size?: "standard" | "large";
 }
 
-export const Card: React.FunctionComponent<Props> = ({
+export const Card: React.FC<Props> = ({
   children,
   heading,
   actions,
@@ -69,7 +67,7 @@ export const Card: React.FunctionComponent<Props> = ({
           marginRight: "auto",
         }}
       >
-        <div css={{ display: "block" }}>
+        <div>
           {heading && (
             <div
               css={{
@@ -82,7 +80,6 @@ export const Card: React.FunctionComponent<Props> = ({
                 css={{
                   fontWeight: 600,
                   flex: "1 1 0%",
-                  lineHeight: 1.5,
                   overflow: "hidden",
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
@@ -98,7 +95,7 @@ export const Card: React.FunctionComponent<Props> = ({
               css={{
                 ...base.base,
                 color: colors.grey.base,
-                maxWidth: actions ? 650 : "",
+                maxWidth: actions ? descriptionMaxWidth : "",
               }}
             >
               {description}
@@ -120,7 +117,7 @@ Card.propTypes = {
   size: PropTypes.oneOf<Props["size"]>(["standard", "large"]),
 };
 
-export const CardSection: React.FunctionComponent<Props> = ({
+export const CardSection: React.FC<Props> = ({
   heading,
   description,
   actions,
@@ -132,7 +129,7 @@ export const CardSection: React.FunctionComponent<Props> = ({
     }}
   >
     <div css={{ flex: "1 1 0%", marginRight: "auto" }}>
-      <div css={{ display: "block" }}>
+      <div>
         {heading && (
           <div
             css={{
@@ -145,7 +142,6 @@ export const CardSection: React.FunctionComponent<Props> = ({
               css={{
                 fontWeight: 600,
                 flex: "1 1 0%",
-                lineHeight: 1.5,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap",
@@ -161,7 +157,7 @@ export const CardSection: React.FunctionComponent<Props> = ({
             css={{
               ...base.base,
               color: colors.grey.base,
-              maxWidth: actions ? 650 : "",
+              maxWidth: actions ? descriptionMaxWidth : "",
             }}
           >
             {description}
@@ -179,9 +175,12 @@ CardSection.propTypes = {
   actions: PropTypes.node,
 };
 
-export const CardSeperator: React.FunctionComponent = () => (
+/**
+ * A border line that can go between two card sections, with appropriate margin applied
+ */
+export const CardSeperator: React.FC = () => (
   <hr
-    style={{
+    css={{
       height: 1,
       borderWidth: 0,
       backgroundColor: colors.silver.dark,

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -62,8 +62,13 @@ export const Card: React.FunctionComponent<Props> = ({
       paddingBottom: size === "large" ? 16 : 28,
     }}
   >
-    <div css={{ display: "flex" }}>
-      <div css={{ flex: "1 1 0%", marginRight: "auto" }}>
+    <div css={{ display: "flex", marginBottom: children ? 24 : 0 }}>
+      <div
+        css={{
+          flex: "1 1 0%",
+          marginRight: "auto",
+        }}
+      >
         <div css={{ display: "block" }}>
           {heading && (
             <div
@@ -103,7 +108,7 @@ export const Card: React.FunctionComponent<Props> = ({
       </div>
       {actions && <div css={{ marginLeft: 16 }}>{actions}</div>}
     </div>
-    {children && <div css={{ paddingTop: 24 }}>{children} </div>}
+    {children}
   </div>
 );
 
@@ -123,6 +128,7 @@ export const CardSection: React.FunctionComponent<Props> = ({
   <div
     css={{
       display: "flex",
+      marginTop: 24,
     }}
   >
     <div css={{ flex: "1 1 0%", marginRight: "auto" }}>

--- a/src/Card/index.ts
+++ b/src/Card/index.ts
@@ -1,0 +1,1 @@
+export * from "./Card";


### PR DESCRIPTION
- Card component
- Section component ![image](https://user-images.githubusercontent.com/14367451/62325332-4a6c9180-b460-11e9-87a5-03ec8c18807a.png) 
  - large / standard size
 - Card story


**Props**

- **children?: React.ReactNode;**
   card content, aligned below title and description and title chlildren

- **title?: React.ReactNode;**
title of the card
- **className?: string;**

- **description?: React.ReactNode;**
same size grey text under the title as seen in designs

- **titleChildren?: React.ReactNode;**
exists for things like left centered buttons and text, as seen in the designs below

- **forceNoChildPadding?: boolean;**
exists only for cards with hidden children (like drawers) to force no bottom padding

- **size?: "standard" | "large";**
two size cards, one for things like the [user management table,](https://app.zeplin.io/project/5b3665ece41d8c86a0f30286/screen/5d095654b2c0555e11b4cba7) and one for [standard cards ](https://app.zeplin.io/project/5b3665ece41d8c86a0f30286/screen/5d3a355f62259b6cb6021358) difference is the size of the title text and the padding


[designs (one of many)](https://app.zeplin.io/project/5b3665ece41d8c86a0f30286/screen/5d0957502ac55d5d2c988ec7)

**TODO:**
- add tests when[ 34](https://github.com/apollographql/space-kit/pull/34) is merged

Questions:
- How organized do we want our storybook? I just added tabs for the cards but they aren't the same sort of feel as the designed and structured stories for buttons, and I never implemented the spec'd storybook for modals. This was because I prioritized getting to use the components in engine.
- right now I have a card section which looks like this 
![image](https://user-images.githubusercontent.com/14367451/62325332-4a6c9180-b460-11e9-87a5-03ec8c18807a.png) and it adds padding to the top whenever you use it, however, if you use it right after a card it will add double padding (one from the card, one from the section) so I have to specify `forceNoChildPadding`. There is definitely a more elegant way to do this, but I will keep thinking about it
