### PR TITLE
Tiny Modal Edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix broken storybook (#39)
 - Remove top level Space Kit namespace in Storybook (#38)
 - Make Icon weight configurable (#33)
+- Edit Modal prop descriptions, fix margin top on children [#41](https://github.com/apollographql/space-kit/pull/41)
 
 ## [`v0.6.2`](https://github.com/apollographql/space-kit/releases/tag/v0.6.2)
 

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -22,9 +22,7 @@ interface Props {
 
   children?: React.ReactNode;
   /**
-   * Optional descrition to show of the modal
-   *
-   * This will probably be moved into a card component
+   * Optional description to show of the modal
    */
   description?: React.ReactNode;
 
@@ -45,8 +43,6 @@ interface Props {
 
   /**
    * Title of the modal
-   *
-   * This will probably be moved into a card component
    */
   title: React.ReactNode;
 }
@@ -157,7 +153,13 @@ export function Modal({
             </div>
           )}
         </div>
-        <div css={{ marginTop: 12 }}>{children}</div>
+        <div
+          css={{
+            marginTop: size === "large" ? 24 : size === "medium" ? 16 : 12,
+          }}
+        >
+          {children}
+        </div>
         {(primaryAction || secondaryAction || bottomLeftText) && (
           <div
             css={{


### PR DESCRIPTION
- just fix the descriptions so there are no references to cards and make the margin of the children size dependent