### PR TITLE
AP-700 Export `emotionCacheProviderFactory` so allow consumers to override classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tsconfig.tsbuildinfo
 # Other modules
 /Button
 /colors
+/emotionCacheProviderFactory
 /fonts
 /icons
 /Modal

--- a/README.md
+++ b/README.md
@@ -59,26 +59,33 @@ function MyComponent() {
 
 ### Emotion
 
-Some components are styled with [emotion](https://emotion.sh) under the hood; emotion appends `<style>` tags to your `<head>` element at runtime. This may cause emotions's styles to be included _after_ your project's styles, preventing you from using your own classes to override emotion's. To get around this, you need to modify how emotion adds styles to the DOM. Check out the [docs](https://emotion.sh/docs/@emotion/cache). Here's an example:
+Some components are styled with [emotion](https://emotion.sh) under the hood; emotion appends `<style>` tags to your `<head>` element at runtime. This may cause emotions's styles to be included _after_ your project's styules, preventing you from using your own classes to override emotion's. 
 
-```ts
-import React from "react";
-import { CacheProvider } from "@emotion/core";
-import createCache from "@emotion/cache";
-import { RealApp } from "./RealApp";
+Ideally we'd be able to use Emotion's `<CacheProvider>` to control where Space Kit's styles would be injected, but an emotion bug ([emotion-js/emotion#1386](https://github.com/emotion-js/emotion/issues/1386)) causes `CacheProvider`s to not be recognized for bundled components.
 
-// This expects you to have added `<style id="emotionStyleContainer"></style>` somewhere to the DOM
-const emotionCache = createCache({
-  container:
-    document.querySelector<HTMLElement>("#emotionStyleContainer") || undefined,
-});
+To get around this issue, we export the `emotionCacheProviderFactor` factory that you can use to create a cache provider that will work.
 
-export const App = (): React.FC => (
-  <CacheProvider value={emotionCache}>
-    <RealApp />
-  </CacheProvider>
+Example:
+
+```tsx
+import { emotionCacheProviderFactory } from '@apollo/space-kit/emotionCacheProviderFactory`;
+
+const CacheProvider = emotionCacheProviderFactor(document.queryElement('#spaceKitEmotionStyleContainer'));
+
+const App = (
+  <CacheProvider>
+    <AppCode />
+  </Cache>
 );
 ```
+
+This expects the following to exist somewhere in the DOM:
+
+```html
+<style id="spaceKitEmotionStyleContainer"></style>
+```
+
+All styles will be placed inside of that component.
 
 ### Stylesheet reset
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       }
     },
     "@emotion/cache": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.14.tgz",
-      "integrity": "sha512-HNGEwWnPlNyy/WPXBXzbjzkzeZFV657Z99/xq2xs5yinJHbMfi3ioCvBJ6Y8Zc8DQzO9F5jDmVXJB41Ytx3QMw==",
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.15.tgz",
+      "integrity": "sha512-8VthgeKhlGeTXSW1JN7I14AnAaiFPbOrqNqg3dPoGCZ3bnMjkrmRU0zrx0BtBw9esBaPaQgDB9y0tVgAGT2Mrg==",
       "requires": {
         "@emotion/sheet": "0.9.3",
         "@emotion/stylis": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/traverse": "^7.5.5",
+    "@emotion/cache": "^10.0.15",
     "@storybook/addon-knobs": "^5.1.9",
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",

--- a/src/emotionCacheProviderFactory/index.tsx
+++ b/src/emotionCacheProviderFactory/index.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { CacheProvider } from "@emotion/core";
+import createCache from "@emotion/cache";
+
+/**
+ * Factory function to create a component that you can wrap your application
+ * with to specify where space kit's emotion classes will be added.
+ *
+ * This function is intenteded to be used like so:
+ *
+ * ```tsx
+ * import { emotionCacheProviderFactory } from '@apollo/space-kit/emotionCacheProviderFactory`;
+ *
+ * const CacheProvider = emotionCacheProviderFactor(document.queryElement('head'));
+ *
+ * const App = (
+ *   <CacheProvider>
+ *     <AppCode />
+ *   </Cache>
+ * );
+ *
+ * @param container {HTMLElement} The container element that you want all your
+ * emotion styles to be placed inside of
+ */
+export function emotionCacheProviderFactory(container?: HTMLElement | null) {
+  // This expects us to have added `<style id="spaceKitEmotionStyleContainer"></style>`
+  // somewhere to the DOM
+  const emotionCache = createCache({
+    // `createCache` expects `container` to be `HTMLElement | undefined`, but
+    // `document.querySelector` returns `Element | null`; so we have to convert
+    // the `null` to `undefined` here.
+    container: container || undefined,
+    key: "space-kit",
+  });
+
+  const EmotionCacheProvider: React.FC = ({ children }) => (
+    <CacheProvider value={emotionCache}>{children}</CacheProvider>
+  );
+
+  return EmotionCacheProvider;
+}


### PR DESCRIPTION
Ideally we'd want to use `<CacheProvder>` in the consumer application just like we'd want to use `<ApolloProvider>`, but a bug in emotion prevents this: https://github.com/emotion-js/emotion/issues/1386

This provides a `emotionCacheProviderFactory` factory that consumers can use to create a `CacheProvider`.

Contributes to [AP-700](https://golinks.io/j/AP-700)