### PR TITLE
Fix modals sizes in Safari

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -51,8 +51,8 @@ const modalBackdrop = css`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
 
   &:after {
     position: fixed;
@@ -65,6 +65,8 @@ const modalBackdrop = css`
     bottom: 0;
     right: 0;
     z-index: -1;
+    height: 100vh;
+    width: 100vw;
   }
 `;
 


### PR DESCRIPTION
## Release Notes

Safari doesn't understand using a height of `100%` for `position: fixed` elements. This will use `100vh` instead of `100%` to match the viewport height.