### PR TITLE
Speed up `check-labels` task by not installing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install npm dependencies
-          command: npm ci
-      - run:
           name: Check labels
           command: npx auto pr-check --pr ${CIRCLE_PULL_REQUEST##*/} --url ${CIRCLE_BUILD_URL}
 


### PR DESCRIPTION
We don't need them because we aren't using any user-code