### PR TITLE
Add workflow to re-run the `check-label` CircleCI job when labels are changed

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,16 @@
+workflow "Re-run check-label when label changes" {
+  resolves = ["fire check-label"]
+  on = "pull_request"
+}
+
+action "action-filter" {
+  uses = "actions/bin/filter@master"
+  args = "action 'labeled|unlabeled'"
+}
+
+action "fire check-label" {
+  uses = "swinton/httpie.action@69125d73caa2c6821f6a41a86112777a37adc171"
+  needs = "action-filter"
+  secrets = ["CIRCLE_API_TOKEN"]
+  args = ["-v", "-a=${CIRCLE_API_TOKEN}:", "POST", "https://circleci.com/api/v1.1/project/github/apollographql/space-kit/tree/${GITHUB_REF#*refs/heads/}", "build_parameters:='{\"CIRCLE_JOB\": \"check-label\"}'"]
+}

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Each PR needs to have a SemVer lable in GitHub so `auto` knows how to . Availabl
 
 Use `skip-release` if you don't want an automatic release with your PR.
 
+There is a CircleCI job that checks that an appropriate label is on the PR. It will always fail initially. GitHub actions are set up to re-run the CI check when labels are added or removed. it can be found in [`.github/main.workflow`](./.github/main.workflow).
+
 #### Changelog
 
 The changelog will be updated automatically with the title of your PR used as the line item in the changelog. The sections of the changelog will decided by the labels you gave your PR. If you want to add more information for the changelog, add a `## Release Notes` section in your PR description. https://intuit.github.io/auto/pages/auto-changelog.html#additional-release-notes


### PR DESCRIPTION
## Release Notes

We have a CircleCI job that will validate that each pull request has valid labels. This will always fail when the PR is initially created because there are no labels.

This creates a GitHub Action that will re-run the CI step whenever labels are added or removed from a PR.