### PR TITLE
remove default size on icons

### DIFF
--- a/src/icons/scripts/convert.ts
+++ b/src/icons/scripts/convert.ts
@@ -133,7 +133,7 @@ function createCSSAttribute(css: string): JSXAttribute {
                   // Add css template literal
                   jsx.openingElement.attributes.push(
                     createCSSAttribute(
-                      "*{vector-effect: non-scaling-stroke} overflow: visible; width: 20px; height: 20px"
+                      "*{vector-effect: non-scaling-stroke} overflow: visible;"
                     )
                   );
                   // We need to add '/** @jsx jsx */' to the top of the file,


### PR DESCRIPTION
this is not useful until we can easily override their sizes in consumers

## Release Notes

There's no easy way to override the classes that we're putting on our Space Kit components until https://github.com/apollographql/space-kit/pull/46 lands. We can't put default sizes on icons because they can't be overridden yet.