### PR TITLE
Fix `npm watch` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "run-p test:typescript",
     "test:typescript": "tsc --noEmit",
     "watch": "run-p watch:*",
-    "watch:typescript": "tsc --watch",
+    "watch:typescript": "tsc tsconfig.build.json --watch",
     "watch:npmwatch": "npm-watch"
   },
   "watch": {


### PR DESCRIPTION
It's broken because it doesn't use the `tsconfig.build.json` file.