### PR TITLE
Automatically calculate button text color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2767,6 +2767,11 @@
       "integrity": "sha512-UYSpRjkiiThPS3L2L7VhmmKGheGmyCBE382LCHaJIjLe6PeBb1HJvUSNqsZyuRyNMGcDcHcBQEV/CovlWjzFsw==",
       "dev": true
     },
+    "@types/tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
+    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -3451,8 +3456,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4991,7 +4995,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5675,8 +5678,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -7013,8 +7015,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -7469,8 +7470,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7491,14 +7491,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7513,20 +7511,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7643,8 +7638,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7656,7 +7650,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7671,7 +7664,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7679,14 +7671,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7705,7 +7695,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7786,8 +7775,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7799,7 +7787,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7885,8 +7872,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7922,7 +7908,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7942,7 +7927,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7986,14 +7970,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9216,8 +9198,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -13394,8 +13375,7 @@
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
-      "dev": true
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
       "version": "0.0.33",
@@ -13566,8 +13546,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "type": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   },
   "dependencies": {
     "@emotion/cache": "^10.0.15",
-    "@emotion/core": "^10.0.15"
+    "@emotion/core": "^10.0.15",
+    "@types/tinycolor2": "^1.4.2",
+    "tinycolor2": "^1.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/src/Button/Button.story.tsx
+++ b/src/Button/Button.story.tsx
@@ -152,9 +152,6 @@ storiesOf("Button", module)
 
         <VerticalButtonGroup
           title="Example 2"
-          buttonCss={{
-            color: colors.white,
-          }}
           buttonProps={{
             color: colors.indigo.dark,
           }}
@@ -168,9 +165,6 @@ storiesOf("Button", module)
 
         <VerticalButtonGroup
           title="Example 3"
-          buttonCss={{
-            color: colors.white,
-          }}
           buttonProps={{
             color: colors.green.base,
           }}
@@ -184,9 +178,6 @@ storiesOf("Button", module)
 
         <VerticalButtonGroup
           title="Example 4"
-          buttonCss={{
-            color: colors.white,
-          }}
           buttonProps={{
             color: colors.red.base,
           }}
@@ -200,9 +191,6 @@ storiesOf("Button", module)
 
         <VerticalButtonGroup
           title="Example 5"
-          buttonCss={{
-            color: colors.white,
-          }}
           buttonProps={{
             color: colors.blue.base,
           }}

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -4,6 +4,7 @@ import * as CSS from "csstype";
 import { base } from "../typography";
 import { jsx } from "@emotion/core";
 import { getOffsetInPalette } from "../colors/utils/getOffsetInPalette";
+import tinycolor from "tinycolor2";
 
 type TLength = string | 0 | number;
 
@@ -35,8 +36,25 @@ function getTextColor({
     case "raised":
     case "secondary":
       // Set the base (meaning no pseudo-selectors) text color for raised and
-      // secondary button. Otherwise return `undefined` to not change the color
-      return !mode ? colors.grey.darker : undefined;
+      // secondary buttons. Otherwise return `undefined` to not change the
+      // color.
+      //
+      // We have some special logic for the raised and secondary color; set the
+      // text color to be what is most readable between white and the default
+      // text color and the _hover_ color's background. This is overrideable by
+      // the user, but it shouldn't need to be.
+      return !mode
+        ? tinycolor
+            .mostReadable(
+              getHoverBackgroundColor({ color, feel, theme }),
+              [colors.white, colors.grey.darker],
+              {
+                level: "AA",
+                size: "small",
+              }
+            )
+            .toString()
+        : undefined;
     case "flat":
       if (color === defaultColor) {
         return theme === "dark" ? colors.grey.light : colors.grey.darker;


### PR DESCRIPTION
Buttons will now determine if they should use `colors.grey.darker` or `colors.white` based on how readable the text color is during the hover state. Note that this lines up perfectly with the text colors used in @adamatorres 's space kit designs!

This also removes the text color overrides in the storybook stories.