### PR TITLE
Small text field fixes

### DIFF
--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -54,7 +54,7 @@ interface Props {
   /**
    * Visible title
    */
-  label: React.ReactNode;
+  label?: React.ReactNode;
 
   /**
    * A short hint that describes the expected value of the input field
@@ -111,7 +111,7 @@ export const TextField: React.FC<Props> = ({
           fontWeight: 600,
         }}
       >
-        <div css={{ marginBottom: 4 }}>{label}</div>
+        {label != null && <div css={{ marginBottom: 4 }}>{label}</div>}
         {description != null && (
           <div
             css={{

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -6,19 +6,11 @@ import { colors } from "../colors";
 import { IconAlertSolid } from "../icons/IconAlertSolid";
 import { IconInfoSolid } from "../icons/IconInfoSolid";
 
-interface Props extends Omit<React.DetailedHTMLProps<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  HTMLInputElement
->, "size"> {
+interface Props {
   /**
    * Class name that will be applied to the wrapping `div` around the component
    */
   className?: string;
-
-  /**
-   * Class name that will be applied to the inner `input`
-   */
-  inputClassName?: string;
 
   /**
    * Value an uncontrolled input will default to
@@ -82,6 +74,16 @@ interface Props extends Omit<React.DetailedHTMLProps<
    * Value of a controlled input
    */
   value?: string | number;
+
+  /**
+   * Name to give the input
+   */
+  name?: string;
+
+  /**
+   * Type of input field
+   */
+  type?: string;
 }
 
 /**
@@ -90,7 +92,6 @@ interface Props extends Omit<React.DetailedHTMLProps<
  */
 export const TextField: React.FC<Props> = ({
   className,
-  inputClassName,
   defaultValue,
   description,
   disabled,
@@ -147,7 +148,6 @@ export const TextField: React.FC<Props> = ({
 
           <input
             {...otherProps}
-            className={inputClassName}
             defaultValue={defaultValue}
             disabled={disabled}
             onChange={onChange}

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -6,7 +6,10 @@ import { colors } from "../colors";
 import { IconAlertSolid } from "../icons/IconAlertSolid";
 import { IconInfoSolid } from "../icons/IconInfoSolid";
 
-interface Props {
+interface Props extends Omit<React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>, "size"> {
   /**
    * Class name that will be applied to the wrapping `div` around the component
    */

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -13,6 +13,11 @@ interface Props {
   className?: string;
 
   /**
+   * Class name that will be applied to the inner `input`
+   */
+  inputClassName?: string;
+
+  /**
    * Value an uncontrolled input will default to
    */
   defaultValue?: string;
@@ -82,6 +87,7 @@ interface Props {
  */
 export const TextField: React.FC<Props> = ({
   className,
+  inputClassName,
   defaultValue,
   description,
   disabled,
@@ -138,6 +144,7 @@ export const TextField: React.FC<Props> = ({
 
           <input
             {...otherProps}
+            className={inputClassName}
             defaultValue={defaultValue}
             disabled={disabled}
             onChange={onChange}


### PR DESCRIPTION
#### Allow input class names
This is needed to opt out of styling from `Input.less`

#### Make label optional again
Im not sure why this went away, adding it back since it seemed like an unintentional change to make it required.

#### Proptypes extends `InputHTMLAttributes`
Im not sure when this went away either, but without it you have to spread props to avoid type errors which isn't very ergonomic, for example
```jsx
{...{
  name: 'password',
  type: 'password',
}}
```
instead of
```jsx
name="password"
type="password"
```