### PR TITLE
Correct npm script for cleaning TextField, make labels optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean:button": "rimraf Button",
     "clean:colors": "rimraf colors",
     "clean:fonts": "rimraf fonts",
-    "clean:formField": "rimraf FormField",
+    "clean:textField": "rimraf TextField",
     "clean:icons": "rimraf icons src/icons/*.tsx",
     "clean:modal": "rimraf Modal",
     "clean:shared": "rimraf shared",


### PR DESCRIPTION
## Release Notes

@justinanastos made an update to the TextField logic and didn't update the clean script. This fixes it.