### PR TITLE
build: update ssh fingerprint to release through `apollo-bot2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             # see https://circleci.com/gh/apollographql/space-kit/edit#checkout
-            - "81:5a:2f:22:7e:92:6a:dc:95:08:87:a3:2e:3a:61:bf"
+            - "c3:d8:f4:b7:55:5c:70:72:51:21:8c:e1:63:92:ce:92"
       - run:
           name: Add NPM_TOKEN to `.npmrc`
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/space-kit/.npmrc


### PR DESCRIPTION
I set up the SSH key for `apollo-bot2` wrong, as I discovered when the last release failed (silently). This time I followed the instructions found here https://circleci.com/docs/2.0/gh-bb-integration/#controlling-access-via-a-machine-user to allow `apollo-bot2` to create it's own read/write ssh key that it can use for releases.