### PR TITLE
AP-714 Move emotion export docs to storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [Exports](#exports)
-  - [Emotion](#emotion)
   - [Stylesheet reset](#stylesheet-reset)
   - [Colors](#colors)
   - [Icons](#icons)
@@ -18,7 +17,6 @@
   - [Buttons](#buttons)
   - [Modals](#modals)
   - [Loaders](#loaders)
-    - [Spinners](#spinners)
   - [Emotion Example](#emotion-example)
 - [Developing Space Kit](#developing-space-kit)
   - [Releases](#releases)
@@ -58,36 +56,6 @@ function MyComponent() {
 ```
 
 ## Exports
-
-### Emotion
-
-Some components are styled with [emotion](https://emotion.sh) under the hood; emotion appends `<style>` tags to your `<head>` element at runtime. This may cause emotions's styles to be included _after_ your project's styules, preventing you from using your own classes to override emotion's. 
-
-Ideally we'd be able to use Emotion's `<CacheProvider>` to control where Space Kit's styles would be injected, but an emotion bug ([emotion-js/emotion#1386](https://github.com/emotion-js/emotion/issues/1386)) causes `CacheProvider`s to not be recognized for bundled components.
-
-To get around this issue, we export the `emotionCacheProviderFactor` factory that you can use to create a cache provider that will work.
-
-Example:
-
-```tsx
-import { emotionCacheProviderFactory } from '@apollo/space-kit/emotionCacheProviderFactory`;
-
-const CacheProvider = emotionCacheProviderFactor(document.queryElement('#spaceKitEmotionStyleContainer'));
-
-const App = (
-  <CacheProvider>
-    <AppCode />
-  </Cache>
-);
-```
-
-This expects the following to exist somewhere in the DOM:
-
-```html
-<style id="spaceKitEmotionStyleContainer"></style>
-```
-
-All styles will be placed inside of that component.
 
 ### Stylesheet reset
 

--- a/src/emotionCacheProviderFactory/emotionCacheProviderFactory.stories.mdx
+++ b/src/emotionCacheProviderFactory/emotionCacheProviderFactory.stories.mdx
@@ -1,0 +1,42 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Guides|Emotion" />
+
+# Emotion
+
+All components are styled with [emotion](https://emotion.sh).
+
+## Control Your Emotion
+
+Emotion appends `<style>` tags to your `<head>` element at runtime. This may cause emotions's styles to be included _after_ your project's styules, preventing you from using your own classes to override emotion's.
+
+Ideally we'd be able to use Emotion's `<CacheProvider>` to control where Space Kit's styles would be injected, but an emotion bug ([emotion-js/emotion#1386](https://github.com/emotion-js/emotion/issues/1386)) causes `CacheProvider`s to not be recognized for bundled components.
+
+To get around this issue, we export the `emotionCacheProviderFactory` factory that you can use to create a cache provider targetting a specific DOM node for emotion's Space Kit styles.
+
+Example:
+
+```jsx
+import { emotionCacheProviderFactory } from "@apollo/space-kit/emotionCacheProviderFactory";
+
+// Create the provider
+const CacheProvider = emotionCacheProviderFactor(
+  // Element we want to target
+  document.queryElement("#spaceKitEmotionStyleContainer")
+);
+
+// Wrap application with `CacheProvider`
+const App = (
+  <CacheProvider>
+    <AppCode />
+  </CacheProvider>
+);
+```
+
+This expects the following to exist somewhere in the DOM:
+
+```html
+<style id="spaceKitEmotionStyleContainer"></style>
+```
+
+All styles will be placed inside of that component.


### PR DESCRIPTION
I'm thinking we should limit how much content we have in the README. I'm thinking maybe we just include how to use the project, how to contribute to the project, and guidelines. Everything else can live in our living documentation system in storybook.

This is just the first step, we can come back to this in the future.