### PR TITLE
AP-808: passthrough `autoFocus` prop to underlying `input` in `TextField`

### DIFF
--- a/src/TextField/TextField.spec.tsx
+++ b/src/TextField/TextField.spec.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { TextField } from "./TextField";
+
+afterEach(cleanup);
+
+test("when passed `autoFocus` prop, should have focus after mounting", () => {
+  const { getByTestId } = render(
+    <TextField autoFocus inputAs={<input data-testid="input" />} />
+  );
+
+  const textField = getByTestId("input");
+
+  expect(textField).toHaveFocus();
+});

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -9,6 +9,11 @@ import classnames from "classnames";
 
 interface Props {
   /**
+   * Passed through to the underlying `input`
+   */
+  autoFocus?: boolean;
+
+  /**
    * Class name that will be applied to the wrapping `div` around the component
    */
   className?: string;
@@ -103,6 +108,7 @@ interface Props {
  * text, and error text.
  */
 export const TextField: React.FC<Props> = ({
+  autoFocus,
   className,
   defaultValue,
   description,
@@ -125,6 +131,7 @@ export const TextField: React.FC<Props> = ({
   <ClassNames>
     {({ css, cx }) => {
       const inputProps = {
+        autoFocus,
         defaultValue,
         disabled,
         name,


### PR DESCRIPTION
Also adds a test to make sure it's working.

Contributes to issue AP-808