### PR TITLE
AP-808 Add `as` prop to `Modal`

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,11 +1,23 @@
 /** @jsx jsx */
-import { jsx, css } from "@emotion/core";
+import { jsx, css, ClassNames } from "@emotion/core";
 import React, { useEffect } from "react";
 import * as typography from "../typography";
 import { colors } from "../colors";
 import * as CSS from "csstype";
+import classnames from "classnames";
 
 interface Props {
+  /**
+   * Override the the default element used to render the outermost component
+   *
+   * All props provided will be merged with props that this component adds,
+   * including `className`s being merged. You can use this to make the modal a
+   * `<form>`
+   *
+   * @default `<div />`
+   */
+  as?: React.ReactElement;
+
   /**
    * Optional primary action, usually a button
    *
@@ -91,7 +103,8 @@ const getModalWidth = (size: Props["size"]): CSS.WidthProperty<TLength> => {
   }
 };
 
-export function Modal({
+export const Modal: React.FC<Props> = ({
+  as = <div />,
   title,
   description,
   children,
@@ -100,7 +113,7 @@ export function Modal({
   bottomLeftText,
   primaryAction,
   secondaryAction,
-}: Props): ReturnType<React.FC> {
+}) => {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.code === "Escape" && onClose) {
@@ -115,74 +128,94 @@ export function Modal({
   });
 
   return (
-    <div onClick={onClose} css={modalBackdrop}>
-      <div
-        onClick={event => event.stopPropagation()}
-        css={{
-          backgroundColor: "white",
-          borderRadius: 12,
-          boxShadow: `0 16px 32px 0 rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(18, 21, 26, 0.04)`,
-          left: "50%",
-          maxHeight: "60%",
-          minWidth: 400,
-          opacity: 1,
-          overflowY: "scroll",
-          padding: size === "large" ? "40px" : "32px",
-          position: "absolute",
-          top: "20%",
-          transform: "translate(-50%)",
-          width: getModalWidth(size),
-          zIndex: 11,
-        }}
-      >
-        <div>
-          {title && (
-            <div>
+    <ClassNames>
+      {({ css, cx }) => {
+        const propsToPass = {
+          onClick: onClose,
+          className: classnames(
+            cx(css(modalBackdrop)),
+            as.props.className,
+            // If the parent component is using emotion with the jsx pragma, we
+            // have to get fancy and intercept the styles to use with the
+            // `ClassNames` wrapper.
+            as.props.css ? css(as.props.css.styles) : null
+          ),
+          children: (
+            <div
+              onClick={event => event.stopPropagation()}
+              css={{
+                backgroundColor: "white",
+                borderRadius: 12,
+                boxShadow: `0 16px 32px 0 rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(18, 21, 26, 0.04)`,
+                left: "50%",
+                maxHeight: "60%",
+                minWidth: 400,
+                opacity: 1,
+                overflowY: "scroll",
+                padding: size === "large" ? "40px" : "32px",
+                position: "absolute",
+                top: "20%",
+                transform: "translate(-50%)",
+                width: getModalWidth(size),
+                zIndex: 11,
+              }}
+            >
+              <div>
+                {title && (
+                  <div>
+                    <div
+                      css={{
+                        color: colors.black.base,
+                        marginBottom: 10,
+                        ...(size === "small"
+                          ? { ...typography.base.large, fontWeight: 600 }
+                          : typography.base.xxlarge),
+                      }}
+                    >
+                      {title}
+                    </div>
+                  </div>
+                )}
+                {description && (
+                  <div
+                    css={{ ...typography.base.base, color: colors.black.base }}
+                  >
+                    {description}
+                  </div>
+                )}
+              </div>
               <div
                 css={{
-                  color: colors.black.base,
-                  marginBottom: 10,
-                  ...(size === "small"
-                    ? { ...typography.base.large, fontWeight: 600 }
-                    : typography.base.xxlarge),
+                  marginTop:
+                    size === "large" ? 24 : size === "medium" ? 16 : 12,
                 }}
               >
-                {title}
+                {children}
               </div>
+              {(primaryAction || secondaryAction || bottomLeftText) && (
+                <div
+                  css={{
+                    alignItems: "center",
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    marginTop: size === "medium" ? 32 : 24,
+                  }}
+                >
+                  {bottomLeftText && (
+                    <div css={{ marginRight: "auto" }}>{bottomLeftText}</div>
+                  )}
+                  {secondaryAction && (
+                    <div css={{ marginRight: 12 }}>{secondaryAction}</div>
+                  )}
+                  {primaryAction && <div>{primaryAction}</div>}
+                </div>
+              )}
             </div>
-          )}
-          {description && (
-            <div css={{ ...typography.base.base, color: colors.black.base }}>
-              {description}
-            </div>
-          )}
-        </div>
-        <div
-          css={{
-            marginTop: size === "large" ? 24 : size === "medium" ? 16 : 12,
-          }}
-        >
-          {children}
-        </div>
-        {(primaryAction || secondaryAction || bottomLeftText) && (
-          <div
-            css={{
-              alignItems: "center",
-              display: "flex",
-              justifyContent: "flex-end",
-              marginTop: size === "medium" ? 32 : 24,
-            }}
-          >
-            {bottomLeftText && (
-              <div css={{ marginRight: "auto" }}>{bottomLeftText}</div>
-            )}
-            {secondaryAction && (
-              <div css={{ marginRight: 12 }}>{secondaryAction}</div>
-            )}
-            {primaryAction && <div>{primaryAction}</div>}
-          </div>
-        )}
-      </div>
-    </div>
+          ),
+        };
+
+        return React.cloneElement(as, propsToPass);
+      }}
+    </ClassNames>
   );
-}
+};


### PR DESCRIPTION
This will let us control the outer element that `Modal`s are rendered with. We're doing this for AP-808 so we can make that outer container a `<form>` so we can use `onSubmit` to handle when a user presses return and when a user clicks on the `<Button type="submit">`

Contributes to issue https://apollographql.atlassian.net/browse/AP-808