### PR TITLE
AP-801 Show appropriate cursor for `Button`'s `loading` and `disabled` states

### DIFF
--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -64,6 +64,29 @@ test("when disabled, button does not call click handlers", () => {
   expect(rootElementOnClick).not.toHaveBeenCalled();
 });
 
+test("when loading, button does not call click handlers", () => {
+  const rootElementOnClick = jest.fn();
+  const asElementOnClick = jest.fn();
+
+  const { getByTestId } = render(
+    <Button
+      as={<button onClick={asElementOnClick} />}
+      data-testid="button"
+      loading
+      onClick={rootElementOnClick}
+    >
+      submit
+    </Button>
+  );
+
+  // act
+  getByTestId("button").click();
+
+  // assert
+  expect(asElementOnClick).not.toHaveBeenCalled();
+  expect(rootElementOnClick).not.toHaveBeenCalled();
+});
+
 test("when clicked should remove focus from itself", () => {
   const { getByTestId } = render(<Button data-testid="button">submit</Button>);
   const button = getByTestId("button");

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -353,6 +353,8 @@ export const Button: React.FC<Props> = ({
 
                 color: getTextColor({ color, feel, theme }),
 
+                cursor: loading || disabled ? "default" : "pointer",
+
                 // Vertically center children
                 display: "inline-flex",
                 justifyContent: "center",
@@ -397,7 +399,6 @@ export const Button: React.FC<Props> = ({
                     theme,
                   }),
                   color: getTextColor({ color, feel, theme, mode: ":hover" }),
-                  cursor: "pointer",
                   ...(feel !== "flat" && {
                     // The `box-shadow` property is copied directly from Zeplin
                     boxShadow:


### PR DESCRIPTION
# Intent

- Loading or disabled buttons don't show a cursor pointer anymore

Contributes to issue [AP-801](https://apollographql.atlassian.net/browse/AP-801)