### PR TITLE
[WIP] fix(modal): Stop modal from closing unexpectedly

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -131,7 +131,7 @@ export const Modal: React.FC<Props> = ({
     <ClassNames>
       {({ css, cx }) => {
         const propsToPass = {
-          onClick: onClose,
+          onMouseDown: onClose,
           className: classnames(
             cx(css(modalBackdrop)),
             as.props.className,
@@ -142,7 +142,7 @@ export const Modal: React.FC<Props> = ({
           ),
           children: (
             <div
-              onClick={event => event.stopPropagation()}
+              onMouseDown={event => event.stopPropagation()}
               css={{
                 backgroundColor: "white",
                 borderRadius: 12,


### PR DESCRIPTION
## Release Notes

We close modals when you click on the shroud. If you mouse down inside the modal, move the mouse outside of the modal, and then mouse-up, the modal closes. We should stop capturing `onClick` and instead look at `mouseDown`.