### PR TITLE
Increase modal max height and center contents

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -67,6 +67,8 @@ interface Props {
 
 const modalBackdrop = css`
   position: fixed;
+  display: flex;
+  align-items: center;
   top: 0;
   left: 0;
   width: 100vw;
@@ -156,13 +158,12 @@ export const Modal: React.FC<Props> = ({
                 borderRadius: 12,
                 boxShadow: `0 16px 32px 0 rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(18, 21, 26, 0.04)`,
                 left: "50%",
-                maxHeight: "60%",
+                maxHeight: "80%",
                 minWidth: 400,
                 opacity: 1,
                 overflowY: "scroll",
                 padding: size === "large" ? "40px" : "32px",
                 position: "absolute",
-                top: "20%",
                 transform: "translate(-50%)",
                 width: getModalWidth(size),
                 zIndex: 11,


### PR DESCRIPTION
We previously had `max-height: 60%` which was too small for a few of our modals. The problem with switching to `max-height: 80%` and `top: 10%` was that all our modals would then exist at the top of the screen, so I switched to centering the modal contents instead of setting `top`.

Fixes https://apollographql.atlassian.net/browse/AP-837 and https://apollographql.atlassian.net/browse/AP-941