### PR TITLE
AP-919 Stop propagation of clicks when disabled using input as

### DIFF
--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -64,6 +64,29 @@ test("when disabled, button does not call click handlers", () => {
   expect(rootElementOnClick).not.toHaveBeenCalled();
 });
 
+test("when disabled, button with 'as={}' does not call click handlers", () => {
+  const rootElementOnClick = jest.fn();
+  const asElementOnClick = jest.fn();
+
+  const { getByTestId } = render(
+    <Button
+      as={<div onClick={asElementOnClick} />}
+      data-testid="button"
+      disabled
+      onClick={rootElementOnClick}
+    >
+      submit
+    </Button>
+  );
+
+  // act
+  getByTestId("button").click();
+
+  // assert
+  expect(asElementOnClick).not.toHaveBeenCalled();
+  expect(rootElementOnClick).not.toHaveBeenCalled();
+});
+
 test("when loading, button does not call click handlers", () => {
   const rootElementOnClick = jest.fn();
   const asElementOnClick = jest.fn();

--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -64,7 +64,7 @@ test("when disabled, button does not call click handlers", () => {
   expect(rootElementOnClick).not.toHaveBeenCalled();
 });
 
-test("when disabled, button with 'as={}' does not call click handlers", () => {
+test("when disabled, button with 'as=' set to not a button element does not call click handlers", () => {
   const rootElementOnClick = jest.fn();
   const asElementOnClick = jest.fn();
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -464,7 +464,7 @@ export const Button: React.FC<Props> = ({
         ),
         disabled,
         onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-          // if (disabled) return event.preventDefault();
+          if (disabled) return event.preventDefault();
 
           if (otherProps.onClick) {
             otherProps.onClick(event);


### PR DESCRIPTION
- First add a failing test for the case when using `as={<div ... >}`. The other test uses `as=` but passes a button so the disabled prop already works as intended.
- Uncomment the line that fixes the test

Fixes https://apollographql.atlassian.net/browse/AP-919