### PR TITLE
AP-1011 Stop wrapping long text in Buttons

### DIFF
--- a/src/Button/Button.stories.mdx
+++ b/src/Button/Button.stories.mdx
@@ -757,3 +757,16 @@ Showing how we could potentially use color with the simple button.
 This component extends `HTMLElement` so that most props you'd want to pass to any element can be passed to this component.
 
 <Props of={Button} />
+
+## Special Cases
+
+These stories are intended for Chromatic and aren't intended for documentation.
+
+<Story name="long wrap">
+  <div style={{ width: 100 }}>
+    <Button>
+      I am some really long text that will be wrapped if we don&apos;t set this
+      up correctly
+    </Button>
+  </div>
+</Story>

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -389,6 +389,8 @@ export const Button: React.FC<Props> = ({
                 outline: 0,
 
                 textDecoration: "none",
+
+                whiteSpace: "nowrap",
               },
 
               !disabled && {


### PR DESCRIPTION
Resolves issue https://apollographql.atlassian.net/browse/AP-1011

# Intent

Stop wrapping long text in Buttons. Instead force the button to grow. See the "long text" storybook story under "Button" to see what this means.

# Review

Review this all at once, it's a small change.

# Additional Notes

I'd much rather there was a way to create a story that didn't show in the mdx docs, but I haven't found a way to do that yet.