### PR TITLE
AP-1099 Remove default width on icons

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -22,9 +22,10 @@
     ],
     "patch": [
       {
-        "name": "🐛 bug fix",
+        "name": "bug fix",
         "title": "🐛  Bug Fix",
-        "description": "Increment the patch version when merged"
+        "description": "Increment the patch version when merged",
+        "color": "#38e153"
       },
       {
         "name": "renovate",

--- a/src/icons/Icons.story.jsx
+++ b/src/icons/Icons.story.jsx
@@ -70,6 +70,7 @@ const AllIcons: React.FC = ({ color, ...otherProps }) =>
             {...otherProps}
             style={{
               color,
+              height: 20,
             }}
           />
         </div>

--- a/src/icons/scripts/convert.ts
+++ b/src/icons/scripts/convert.ts
@@ -1,30 +1,15 @@
+import * as types from "@babel/types";
 import fs from "fs";
 import path from "path";
 import svgr from "@svgr/core";
 import { formatComponentName } from "./formatComponentName";
 import { svgo } from "./convertUtils/setupSvgo";
-import {
-  binaryExpression,
-  conditionalExpression,
-  identifier,
-  jsxAttribute,
-  JSXElement,
-  jsxExpressionContainer,
-  jsxIdentifier,
-  JSXOpeningElement,
-  numericLiteral,
-  stringLiteral,
-  taggedTemplateExpression,
-  templateElement,
-  templateLiteral,
-  JSXAttribute,
-} from "@babel/types";
 import traverse from "@babel/traverse";
 
 const SVG_PATH = path.resolve(__dirname, "..", "svgs");
 const COMPONENT_PATH = path.resolve(__dirname, "..");
 
-function updateStrokeWidths(node: JSXOpeningElement) {
+function updateStrokeWidths(node: types.JSXOpeningElement) {
   node.attributes.forEach(attribute => {
     if (
       attribute.type === "JSXAttribute" &&
@@ -33,30 +18,30 @@ function updateStrokeWidths(node: JSXOpeningElement) {
       attribute.value &&
       attribute.value.type === "JSXExpressionContainer"
     ) {
-      attribute.value = jsxExpressionContainer(
-        conditionalExpression(
-          binaryExpression(
+      attribute.value = types.jsxExpressionContainer(
+        types.conditionalExpression(
+          types.binaryExpression(
             "===",
-            identifier("weight"),
-            stringLiteral("normal")
+            types.identifier("weight"),
+            types.stringLiteral("normal")
           ),
-          numericLiteral(1.5),
-          numericLiteral(1)
+          types.numericLiteral(1.5),
+          types.numericLiteral(1)
         )
       );
     }
   });
 }
 
-function createCSSAttribute(css: string): JSXAttribute {
-  return jsxAttribute(
-    jsxIdentifier("css"),
-    jsxExpressionContainer(
-      taggedTemplateExpression(
-        identifier("css"),
-        templateLiteral(
+function createCSSAttribute(css: string): types.JSXAttribute {
+  return types.jsxAttribute(
+    types.jsxIdentifier("css"),
+    types.jsxExpressionContainer(
+      types.taggedTemplateExpression(
+        types.identifier("css"),
+        types.templateLiteral(
           [
-            templateElement(
+            types.templateElement(
               {
                 raw: css,
                 cooked: css,
@@ -117,7 +102,11 @@ function createCSSAttribute(css: string): JSXAttribute {
                     imports,
                     componentName,
                     jsx,
-                  }: { imports: any; componentName: string; jsx: JSXElement }
+                  }: {
+                    imports: any;
+                    componentName: string;
+                    jsx: types.JSXElement;
+                  }
                 ) {
                   const typeScriptTpl = template.smart({
                     plugins: ["typescript"],


### PR DESCRIPTION
## Release notes

We tried setting a default height and width for icons, but this ran into issues with rectangular icons where we were required to set a width and a height. Per @daniman 's suggestion we'll just set the height. I chose to set it to the viewbox height and users can override this if they want to.