### PR TITLE
AP-1075 Fix spinner remounting restarts

### DIFF
--- a/src/Loaders/LoadingSpinner.tsx
+++ b/src/Loaders/LoadingSpinner.tsx
@@ -73,6 +73,9 @@ export const LoadingSpinner: React.FC<Props> = ({
 
   const pixelSize = SIZE_MAP[size];
 
+  const mountTime = React.useRef(Date.now());
+  const mountDelay = -(mountTime.current % 540);
+
   return (
     <svg
       className={className}
@@ -97,6 +100,7 @@ export const LoadingSpinner: React.FC<Props> = ({
           css={{
             animation: `${SPIN} 540ms linear infinite`,
             willChange: "transform",
+            animationDelay: `${mountDelay}ms`,
           }}
           fill={asteroidColor}
           r="10"

--- a/src/Loaders/LoadingSpinner.tsx
+++ b/src/Loaders/LoadingSpinner.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import React from "react";
 import * as CSS from "csstype";
+import isChromatic from "storybook-chromatic/isChromatic";
 import { jsx, keyframes } from "@emotion/core";
 import { colors } from "../colors";
 
@@ -74,7 +75,7 @@ export const LoadingSpinner: React.FC<Props> = ({
   const pixelSize = SIZE_MAP[size];
 
   const mountTime = React.useRef(Date.now());
-  const mountDelay = -(mountTime.current % 540);
+  const mountDelay = isChromatic() ? 0 : -(mountTime.current % 540);
 
   return (
     <svg

--- a/typings/storybook-chromatic__isChromatic/index.d.ts
+++ b/typings/storybook-chromatic__isChromatic/index.d.ts
@@ -1,0 +1,4 @@
+declare module "storybook-chromatic/isChromatic" {
+  const isChromatic: () => boolean;
+  export default isChromatic;
+}


### PR DESCRIPTION
Take the approach outlined in https://dev.to/selbekk/how-to-stop-your-spinner-from-jumping-in-react-5cmp to stop the spinner from restarting the animation when remounted. This should fix the loader animation restarts described in https://apollographql.atlassian.net/browse/AP-1075.

This worked writing a local story that remounted the component but I was having a really rough time trying to get the linked version to run properly so 🙏 it works properly in that situation as well.