### PR TITLE
remove unnecessary scrollbar

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -172,7 +172,7 @@ export const Modal: React.FC<Props> = ({
                 maxHeight: "80%",
                 minWidth: 400,
                 opacity: 1,
-                overflowY: "scroll",
+                overflowY: "auto",
                 padding: size === "large" ? "40px" : "32px",
                 position: "absolute",
                 width: getModalWidth(size),


### PR DESCRIPTION
`overflow: scroll` results in a scroll bar showing up on windows even when it doesn't make sense. should use `overflow: auto` instead

![image](https://user-images.githubusercontent.com/743976/69061960-2a99b300-09e8-11ea-964a-b9f6d81ab11b.png)

