### PR TITLE
Stop stripping comments from TypeScript builds

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "outDir": ".",
     "pretty": true,
-    "removeComments": true,
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "outDir": ".",
     "pretty": true,
-    "removeComments": true,
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
We need them for jsdoc docs to propogate to consumers!

_I'm merging this without review as soon as it passes CI._