### PR TITLE
Fix: avoid descriptions pushing actions off-screen - AP-1138

### DIFF
--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -106,4 +106,37 @@ storiesOf("Card", module)
         />
       </Card>
     </div>
+  ))
+  .add("Narrow card with really wide nested content", () => (
+    <div
+      style={{
+        backgroundColor: colors.silver.light,
+        padding: "40px",
+        height: "100vh",
+        width: "500px",
+      }}
+    >
+      <Card
+        heading="Card heading"
+        description={
+          <div style={{ whiteSpace: "nowrap", display: "flex" }}>
+            <span>some short text&nbsp;</span>
+            <span
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              https://engine-staging.apollographql.com/account/gh.mdg-private/invite/c7b3eec0-4eab-4c8d-80a7-ea22cae89de1
+            </span>
+          </div>
+        }
+        actions={
+          <Button color={colors.red.base}>
+            <div style={{ color: colors.white }}>Click</div>
+          </Button>
+        }
+      />
+    </div>
   ));

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -54,6 +54,7 @@ export const Card: React.FC<CardProps> = ({
         css={{
           flex: "1 1 0%",
           marginRight: "auto",
+          overflow: "hidden",
         }}
       >
         <div>


### PR DESCRIPTION
Also added a storybook to ensure this remains fixed

before:
![image](https://user-images.githubusercontent.com/743976/69576672-cef89800-0f9a-11ea-9a6a-dd6a8ce92d08.png)

after:
![image](https://user-images.githubusercontent.com/743976/69576687-d5870f80-0f9a-11ea-91cd-a364faf6d73b.png)
