### PR TITLE
AP-1335 Implement Menus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tsconfig.tsbuildinfo
 /SpaceKitProvider
 /Table
 /Tooltip
+/Menu*
 /typography
 
 # Generated icons stored in src directory 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,6 +40,7 @@ function CJS() {
             path.join("src", "illustrations", "scripts"),
             path.join("src", "shared"),
             path.join("src", "AbstractTooltip"),
+            path.join("src", "MenuIconSize"),
           ].some(excludedPathname => filename.includes(excludedPathname))
       ),
     external: [

--- a/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
+++ b/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
@@ -7,30 +7,32 @@ import { Global, css } from "@emotion/core";
 export const TippyStyles: React.FC = () => (
   <Global
     styles={css({
-      ".tippy-tooltip.space-kit-theme": {
-        ...base.small,
-        backgroundColor: colors.black.base,
-        opacity: 0.95,
+      ".tippy-tooltip": {
+        "&.space-kit-theme": {
+          ...base.small,
+          backgroundColor: colors.black.base,
+          opacity: 0.95,
 
-        '&[data-placement^="top"] > .tippy-arrow': {
-          borderTopColor: colors.black.base,
-        },
-        '&[data-placement^="bottom"] > .tippy-arrow': {
-          borderBottomColor: colors.black.base,
-        },
-        '&[data-placement^="right"] > .tippy-arrow': {
-          borderRightColor: colors.black.base,
-        },
-        '&[data-placement^="left"] > .tippy-arrow': {
-          borderLeftColor: colors.black.base,
-        },
+          '&[data-placement^="top"] > .tippy-arrow': {
+            borderTopColor: colors.black.base,
+          },
+          '&[data-placement^="bottom"] > .tippy-arrow': {
+            borderBottomColor: colors.black.base,
+          },
+          '&[data-placement^="right"] > .tippy-arrow': {
+            borderRightColor: colors.black.base,
+          },
+          '&[data-placement^="left"] > .tippy-arrow': {
+            borderLeftColor: colors.black.base,
+          },
 
-        ".tippy-content": {
-          padding: "4px 8px",
-        },
+          ".tippy-content": {
+            padding: "4px 8px",
+          },
 
-        "&.space-kit-relaxed .tippy-content": {
-          padding: "8px 12px",
+          "&.space-kit-relaxed .tippy-content": {
+            padding: "8px 12px",
+          },
         },
       },
     })}

--- a/src/AbstractTooltip/index.tsx
+++ b/src/AbstractTooltip/index.tsx
@@ -44,8 +44,8 @@ export const AbstractTooltip: React.FC<Props> = ({
         hideOnClick={forceVisibleForTestingOnly ? false : hideOnClick}
         trigger={forceVisibleForTestingOnly ? "manual" : trigger}
         visible={forceVisibleForTestingOnly ? true : undefined}
-        {...props}
         theme="space-kit"
+        {...props}
         className={classnames(className, {
           "space-kit-relaxed": padding === "relaxed",
         })}

--- a/src/Menu/Menu.story.mdx
+++ b/src/Menu/Menu.story.mdx
@@ -1,0 +1,272 @@
+import userEvent from "@testing-library/user-event";
+import { findByText } from "@testing-library/dom";
+import { Button } from "../Button";
+import { colors } from "../colors";
+import { Menu } from "../Menu";
+import { PerformUserInteraction } from "./menuStory/PerformUserInteraction";
+import { MenuItem } from "../MenuItem";
+import { MenuDivider } from "../MenuDivider";
+import { MenuHeading } from "../MenuHeading";
+import {
+  Description,
+  Meta,
+  Story,
+  Props,
+  Preview,
+} from "@storybook/addon-docs/blocks";
+import { IconAstronaut1 } from "../icons/IconAstronaut1";
+import { IconAstronaut2 } from "../icons/IconAstronaut2";
+import { IconAstronaut3 } from "../icons/IconAstronaut3";
+import { IconLander } from "../icons/IconLander";
+import { IconPlanet3 } from "../icons/IconPlanet3";
+import { IconShip3 } from "../icons/IconShip3";
+import { IconCheck } from "../icons/IconCheck";
+
+<Meta title="Components|Menu" />
+
+# Menu
+
+<Description
+  of={Menu}
+  markdown="**Menus** provide a way for sures to interact with the application by selecting from a set of options. While that’s simple in theory, menus can be complex and not eveything is detailed below. Menus can emerge from Select buttons or a simple button."
+/>
+
+## Simple Menu
+
+The simple menu provides a list of options for a user to choose from and updates the button or select button with the choice the user has selected.
+
+<Preview>
+  <Story name="basic">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByText(document.body, /open menu/i));
+      }}
+    >
+      <Menu
+        placement="bottom-start"
+        content={
+          <React.Fragment>
+            <MenuItem>Root</MenuItem>
+            <MenuItem selected>Objects</MenuItem>
+            <MenuItem>Inputs</MenuItem>
+            <MenuItem>Interfaces</MenuItem>
+            <MenuItem>Unions</MenuItem>
+            <MenuItem>Scalars and Enums</MenuItem>
+          </React.Fragment>
+        }
+      >
+        <Button>Open Menu</Button>
+      </Menu>
+    </PerformUserInteraction>
+  </Story>
+</Preview>
+
+## Segmented Menu
+
+The segmented menu provides a way to group related options. This can be achieved
+by a divider and in other cases, headers can be used to group similar
+information and provide a nice visual grouping.
+
+<Preview>
+  <Story name="divided">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByText(document.body, /open menu/i));
+      }}
+    >
+      <Menu
+        placement="bottom-start"
+        content={
+          <React.Fragment>
+            <MenuItem>All Types</MenuItem>
+            <MenuDivider />
+            <MenuItem>Root</MenuItem>
+            <MenuItem>Objects</MenuItem>
+            <MenuItem>Inputs</MenuItem>
+            <MenuItem>Interfaces</MenuItem>
+            <MenuItem>Unions</MenuItem>
+            <MenuItem>Scalars and Enums</MenuItem>
+            <MenuDivider />
+            <MenuItem>Deprecations</MenuItem>
+          </React.Fragment>
+        }
+      >
+        <Button>Open Menu</Button>
+      </Menu>
+    </PerformUserInteraction>
+  </Story>
+</Preview>
+
+## Header
+
+<Preview>
+  <Story name="heading">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByText(document.body, /open menu/i));
+      }}
+    >
+      <Menu
+        placement="bottom-start"
+        content={
+          <React.Fragment>
+            <MenuHeading count={5}>Filter by</MenuHeading>
+            <MenuItem>Root</MenuItem>
+            <MenuItem>Objects</MenuItem>
+            <MenuItem>Inputs</MenuItem>
+            <MenuItem>Interfaces</MenuItem>
+            <MenuItem>Unions</MenuItem>
+            <MenuItem>Scalars and Enums</MenuItem>
+          </React.Fragment>
+        }
+      >
+        <Button>Open Menu</Button>
+      </Menu>
+    </PerformUserInteraction>
+  </Story>
+</Preview>
+
+## Icons
+
+<Preview>
+  <Story name="icons">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByText(document.body, /open menu/i));
+      }}
+    >
+      <Menu
+        placement="bottom-start"
+        content={
+          <React.Fragment>
+            <MenuItem
+              icon={
+                <IconAstronaut1
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Cones
+            </MenuItem>
+            <MenuItem
+              icon={
+                <IconAstronaut2
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Rhomboid
+            </MenuItem>
+            <MenuItem
+              icon={
+                <IconAstronaut3
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Cubes
+            </MenuItem>
+            <MenuItem
+              icon={
+                <IconLander
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Diamonds
+            </MenuItem>
+            <MenuItem
+              icon={
+                <IconPlanet3
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Cylinders
+            </MenuItem>
+            <MenuItem
+              icon={
+                <IconShip3
+                  style={{ width: "100%", height: "100%" }}
+                  weight="thin"
+                />
+              }
+            >
+              Pyramids
+            </MenuItem>
+          </React.Fragment>
+        }
+      >
+        <Button>Open Menu</Button>
+      </Menu>
+    </PerformUserInteraction>
+  </Story>
+</Preview>
+
+## Icons with custom sizes
+
+<Preview>
+  <Story name="menu-icon-size">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByText(document.body, /open menu/i));
+      }}
+    >
+      <Menu
+        placement="bottom-start"
+        iconSize="small"
+        maxWidth={280}
+        content={
+          <React.Fragment>
+            <MenuHeading icon={null}>mdg-private-graphs</MenuHeading>
+            <MenuItem icon={null}>apollo-day-nyc</MenuItem>
+            <MenuItem icon={null} selected>
+              engine
+            </MenuItem>
+            <MenuItem icon={null}>galaxy-eu-west</MenuItem>
+            <MenuItem
+              icon={
+                <IconCheck
+                  style={{
+                    color: colors.blue.base,
+                    width: "100%",
+                    height: "100%",
+                  }}
+                />
+              }
+            >
+              galaxy-ties
+            </MenuItem>
+            <MenuItem icon={null}>space-explorer</MenuItem>
+            <MenuItem icon={null}>z-end-to-end-ingestion-20</MenuItem>
+          </React.Fragment>
+        }
+      >
+        <Button>Open Menu</Button>
+      </Menu>
+    </PerformUserInteraction>
+  </Story>
+</Preview>
+
+## Props
+
+### `Menu`
+
+<Props of={Menu} />
+
+### `MenuItem`
+
+<Props of={MenuItem} />
+
+### `MenuHeading`
+
+<Props of={MenuHeading} />
+
+### `MenuDivider`
+
+<Props of={MenuDivider} />

--- a/src/Menu/index.tsx
+++ b/src/Menu/index.tsx
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import React from "react";
+import { AbstractTooltip } from "../AbstractTooltip";
+import { TippyMenuStyles } from "./menu/TippyMenuStyles";
+import {
+  IconSize,
+  MenuIconSizeProvider,
+  useMenuIconSize,
+} from "../MenuIconSize";
+import { Instance, ReferenceElement } from "tippy.js";
+
+interface Props
+  extends Pick<
+    React.ComponentProps<typeof AbstractTooltip>,
+    | "children"
+    | "content"
+    | "flip"
+    | "flipBehavior"
+    | "flipOnUpdate"
+    | "maxWidth"
+    | "placement"
+    | "trigger"
+  > {
+  className?: string;
+
+  /**
+   * Optionally set the icon size to use for all `MenuItem` descendents. This
+   * value will automatically be passed down via context and can be overriden by
+   * child `Menu` components
+   *
+   * Is inherited by antecedent definitions
+   *
+   * @default "normal"
+   */
+  iconSize?: IconSize;
+
+  /**
+   * Popper instance reference
+   *
+   * You'll need this to be able to call methods on the popper instance itself,
+   * such as wishing to hide the menu when a user clicks something.
+   *
+   * When using TypeScript, use this to create your own refs:
+   *
+   * ```tsx
+   * const menuInstanceRef = React.useRef<
+   *   NonNullable<React.ComponentProps<typeof Menu>['instanceRef']>['current']
+   * >()
+   * ```
+   */
+  instanceRef?: React.MutableRefObject<
+    | Parameters<
+        NonNullable<React.ComponentProps<typeof AbstractTooltip>["onCreate"]>
+      >[0]
+    | undefined
+  >;
+
+  /**
+   * Determines if the content should be given a max-height so it can be
+   * scrolled
+   */
+  scrollableContent?: boolean;
+
+  style?: React.CSSProperties;
+}
+
+/**
+ * Given an popper `Instance`, calculate the maximum height popper can take
+ */
+function calculateMaxHeight(instance: Instance) {
+  const parentHeight =
+    instance.props.appendTo === "parent"
+      ? (instance.reference as any).offsetParent.offsetHeight
+      : document.body.clientHeight;
+
+  const {
+    height: referenceHeight,
+    top: referenceTop,
+  } = instance.reference.getBoundingClientRect();
+
+  const {
+    height: arrowHeight,
+  } = instance.popperChildren.arrow?.getBoundingClientRect() ?? { height: 0 };
+
+  const { distance } = instance.props;
+
+  return (
+    parentHeight -
+    referenceTop -
+    referenceHeight -
+    arrowHeight -
+    parseFloat(getComputedStyle(instance.popperChildren.tooltip).paddingTop) -
+    parseFloat(
+      getComputedStyle(instance.popperChildren.tooltip).paddingBottom
+    ) -
+    (typeof distance === "number" ? distance : 0) -
+    // Margin from bottom of the page
+    5
+  );
+}
+
+function isReferenceObject(reference: any): reference is ReferenceElement {
+  return typeof (reference as ReferenceElement)._tippy !== "undefined";
+}
+
+/**
+ * Menu element
+ */
+export const Menu: React.FC<Props> = ({
+  children,
+  iconSize,
+  instanceRef,
+  scrollableContent = false,
+  ...props
+}) => {
+  const inheritedIconSize = useMenuIconSize();
+
+  return (
+    <MenuIconSizeProvider iconSize={iconSize ?? inheritedIconSize}>
+      <TippyMenuStyles />
+      <AbstractTooltip
+        appendTo="parent"
+        onCreate={instance => {
+          if (instanceRef) {
+            instanceRef.current = instance;
+          }
+        }}
+        hideOnClick
+        theme="space-kit-menu"
+        trigger="mousedown"
+        popperOptions={{
+          positionFixed: true,
+          modifiers: {
+            preventOverflow: {
+              boundariesElement: "window",
+              // This will ensure that the menu is correctly placed when a
+              // parent is using an overflow container @see
+              // https://github.com/popperjs/popper-core/issues/535#issuecomment-361628222
+              escapeWithReference: true,
+            },
+            setMaxHeight: {
+              enabled: scrollableContent,
+              order: 0,
+              fn: data => {
+                const reference = data.instance.reference;
+                if (isReferenceObject(reference) && reference._tippy) {
+                  const tippy = reference._tippy;
+                  const calculatedMaxHeight = calculateMaxHeight(tippy);
+                  tippy.popperChildren.content.style.maxHeight = `${calculatedMaxHeight}px`;
+                }
+                return data;
+              },
+            },
+          },
+        }}
+        {...props}
+        interactive
+      >
+        {children}
+      </AbstractTooltip>
+    </MenuIconSizeProvider>
+  );
+};

--- a/src/Menu/menu/TippyMenuStyles.tsx
+++ b/src/Menu/menu/TippyMenuStyles.tsx
@@ -1,0 +1,29 @@
+import "../../../node_modules/tippy.js/dist/tippy.css";
+import React from "react";
+import { base } from "../../typography";
+import { colors } from "../../colors";
+import { Global, css } from "@emotion/core";
+
+export const TippyMenuStyles: React.FC = () => (
+  <Global
+    styles={css({
+      ".tippy-tooltip": {
+        "&.space-kit-menu-theme": {
+          ...base.small,
+          backgroundColor: colors.white,
+          borderRadius: 4,
+          boxShadow:
+            "0 3px 4px 0 rgba(18, 21, 26, 0.04), 0 4px 8px 0 rgba(18, 21, 26, 0.08), 0 0 0 1px rgba(18, 21, 26, 0.08)",
+          color: colors.black.base,
+          padding: 8,
+          minWidth: 190,
+
+          ".tippy-content": {
+            padding: "0",
+            overflowY: "auto",
+          },
+        },
+      },
+    })}
+  />
+);

--- a/src/Menu/menuStory/PerformUserInteraction.tsx
+++ b/src/Menu/menuStory/PerformUserInteraction.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface PerformUserInteractionProps {
+  /**
+   * Callback to call with `setImmediate`. Rendering will always be async, so
+   * you should not expect your dom to be rendered when the callback is fired.
+   * Use async
+   * [`findBy*`](https://testing-library.com/docs/dom-testing-library/api-queries#findby)
+   * methods in
+   * [`@testing-library/dom`](https://github.com/testing-library/dom-testing-library)
+   * to find elements you want to interact with
+   */
+  callback: () => Promise<void>;
+}
+
+/**
+ * Test component to execute a callback after rendering has begun.
+ *
+ * Renders will always be async, so you should use the async
+ * [`findBy*`](https://testing-library.com/docs/dom-testing-library/api-queries#findby)
+ * methods in
+ * [`@testing-library/dom`](https://github.com/testing-library/dom-testing-library)
+ */
+export const PerformUserInteraction: React.FC<PerformUserInteractionProps> = ({
+  callback,
+  children,
+}) => {
+  React.useEffect(() => {
+    setImmediate(callback);
+  });
+
+  return <>{children}</>;
+};

--- a/src/MenuDivider/index.tsx
+++ b/src/MenuDivider/index.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/** @jsx jsx */
+import React from "react";
+import { css, jsx } from "@emotion/core";
+import { colors } from "../colors";
+
+/**
+ * Divider between sections in a menu
+ */
+export const MenuDivider: React.FC = () => {
+  return (
+    <hr
+      css={css({
+        marginLeft: -8,
+        marginRight: -8,
+        marginTop: 8,
+        marginBottom: 8,
+        borderTopColor: colors.silver.base,
+        borderTopWidth: 1,
+        borderTopStyle: "solid",
+        borderBottomWidth: 0,
+        borderLeftWidth: 0,
+        borderRightWidth: 0,
+      })}
+    />
+  );
+};

--- a/src/MenuHeading/index.tsx
+++ b/src/MenuHeading/index.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/** @jsx jsx */
+import React from "react";
+import { css, jsx } from "@emotion/core";
+import { colors } from "../colors";
+import { MenuItem } from "../MenuItem";
+
+interface Props extends React.ComponentProps<typeof MenuItem> {
+  /**
+   * Add a number as a right adornment. Usually used to express a count
+   */
+  count?: React.ReactNode;
+}
+
+/**
+ * Heading intended to be used in a menu. Can also be used to deliniate between
+ * sections in a single menu.
+ *
+ * Composed with and accepts all props of `MenuItem`
+ */
+export const MenuHeading = React.forwardRef<
+  HTMLHeadingElement,
+  React.PropsWithChildren<Props>
+>(({ children, count, ...props }, ref) => {
+  return (
+    <MenuItem {...props} interactive={false} ref={ref}>
+      <h2
+        css={css({
+          display: "flex",
+          fontSize: "inherit",
+          fontWeight: 600,
+          margin: 0,
+          marginBottom: 2,
+          marginTop: 3,
+          textTransform: "uppercase",
+          width: "100%",
+        })}
+        ref={ref}
+      >
+        <span css={css({ flex: "1" })}>{children}</span>
+        {count && (
+          <span
+            css={css({
+              color: colors.grey.light,
+              flex: "none",
+              fontWeight: "normal",
+            })}
+          >
+            {count}
+          </span>
+        )}
+      </h2>
+    </MenuItem>
+  );
+});

--- a/src/MenuIconSize/index.tsx
+++ b/src/MenuIconSize/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+/**
+ * Enumeration of all icon sizes
+ *
+ * This uses string literals instead of a TypeScript union so we can use
+ * strings, like `"small"`, for props instead of `IconSize.small`
+ */
+export type IconSize = "small" | "normal";
+
+const MenuIconSizeContext = React.createContext<IconSize | undefined>(
+  undefined
+);
+
+interface Props {
+  /**
+   * Icon size to use for all descendents
+   */
+  iconSize: IconSize;
+}
+
+/**
+ * Provider to set `IconSize` on the context
+ *
+ * This value is immutable; it's defined when instantiated
+ */
+export const MenuIconSizeProvider: React.FC<Props> = ({
+  children,
+  iconSize,
+}) => {
+  return (
+    <MenuIconSizeContext.Provider value={iconSize}>
+      {children}
+    </MenuIconSizeContext.Provider>
+  );
+};
+
+interface withMenuIconSizeProps {
+  /**
+   * Render prop function. Calls the callback in the shape of `{ iconSize:
+   * IconSize }`
+   */
+  children: (renderPropValues: { iconSize: IconSize }) => ReturnType<React.FC>;
+}
+
+/**
+ * Extract `IconSize` from context.
+ *
+ * *Avoid this component.* This is intended to be used _only_ in the case where
+ * you can't use hooks because you're rendering something under another render
+ * prop component.
+ */
+export const WithMenuIconSize: React.FC<withMenuIconSizeProps> = ({
+  children,
+}) => (
+  <MenuIconSizeContext.Consumer>
+    {iconSize => children({ iconSize: iconSize || "normal" })}
+  </MenuIconSizeContext.Consumer>
+);
+
+/**
+ * Extract `IconSize` from context
+ *
+ * Uses a reasonable default as we don't require any consumer to use
+ * `IconSizeProvider`
+ */
+export function useMenuIconSize(): IconSize {
+  const iconSize = React.useContext(MenuIconSizeContext);
+
+  return iconSize ?? "normal";
+}

--- a/src/MenuItem/index.tsx
+++ b/src/MenuItem/index.tsx
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/** @jsx jsx */
+import * as CSS from "csstype";
+import React from "react";
+import { css, jsx } from "@emotion/core";
+import { colors } from "../colors";
+import { useMenuIconSize } from "../MenuIconSize";
+
+/* istanbul ignore next */
+function assertUnreachable(value: never): never {
+  throw new TypeError(`Unreachable value reached ${value}`);
+}
+
+function getIconHorizontalPadding(
+  iconSize: ReturnType<typeof useMenuIconSize>
+): CSS.PaddingProperty<number> {
+  switch (iconSize) {
+    case "normal":
+      return 12;
+    case "small":
+      return 8;
+    default:
+      assertUnreachable(iconSize);
+  }
+}
+
+function getIconSize(
+  iconSize: ReturnType<typeof useMenuIconSize>
+): CSS.WidthProperty<number> {
+  switch (iconSize) {
+    case "normal":
+      return 16;
+    case "small":
+      return 10;
+    default:
+      assertUnreachable(iconSize);
+  }
+}
+
+function getIconMarginLeft(
+  iconSize: ReturnType<typeof useMenuIconSize>
+): CSS.MarginLeftProperty<number> {
+  switch (iconSize) {
+    case "normal":
+      return "initial";
+    case "small":
+      return -7;
+    default:
+      assertUnreachable(iconSize);
+  }
+}
+
+interface Props
+  extends Pick<
+    React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      HTMLDivElement
+    >,
+    "onClick"
+  > {
+  className?: string;
+  /** Icon to display to the left of the menu item.
+   *
+   * This element will always be rendered unless the value is `undefined`. If
+   * you want an empty node, a spacer for example, use `null`
+   */
+  icon?: React.ReactNode;
+  selected?: boolean;
+  /**
+   * Indicates if this menu item can be itneracted with. Defaults to `true`. If
+   * set to `false`, there will be no hover effects.
+   *
+   * This is _not_ the same as `disabled`
+   */
+  interactive?: boolean;
+}
+
+export const MenuItem = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<Props>
+>(({ children, interactive = true, icon, selected = false, ...props }, ref) => {
+  const iconSize = useMenuIconSize();
+
+  const selectedStyles = interactive && {
+    backgroundColor: colors.blue.base,
+    color: colors.white,
+  };
+
+  return (
+    <div
+      {...props}
+      css={css({
+        ...(selected && selectedStyles),
+        "&:hover": selectedStyles,
+        color:
+          selected && selectedStyles ? selectedStyles.color : colors.black.base,
+        cursor: interactive ? "pointer" : undefined,
+        borderRadius: 4,
+        display: "flex",
+        paddingLeft: 12,
+        paddingRight: 12,
+        paddingTop: 4,
+        paddingBottom: 4,
+      })}
+      ref={ref}
+    >
+      {typeof icon !== "undefined" && (
+        <div
+          css={css({
+            flex: "none",
+            height: 20,
+            marginLeft: getIconMarginLeft(iconSize),
+            marginRight: getIconHorizontalPadding(iconSize),
+            width: getIconSize(iconSize),
+          })}
+        >
+          {icon}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+});


### PR DESCRIPTION
Contributes to https://apollographql.atlassian.net/browse/AP-1335

# Intent

Create a menu system based on https://zpl.io/adX0ELe. Check the examples in the storybook docs to see how to compose menus together!

Uses tippy.js under the hood, just like our tooltips.

This has a bug that can't be fixed until https://github.com/atomiks/tippyjs/issues/678 lands sometime in February. Popper v1 can't reliably figure out the boundaries of a tooltip nested below a component using overflow scrolling. This is resolved in popper v2; but that's not yet included in tippy because it's a breaking change. Fortunately the project maintainers are the same people so they're working on it.

It was a challenge to make the content scrollable if it overflowed the container, but that's included.

# Tests

There aren't any. If you can think of any worth adding, I'd love to!

# Multilevel Menus

These are supported out of the box with the underlying tippy.js library; we just haven't implemented it here yet, which is fine.

# Details

This includes these new components:

* `Menu`

    The parent of a menu. Nesting doesn't work yet; we'll follow up with that if/when we need it. Tippy does support it, we just have to set it up.

* `MenuItem`

    Item in the menu

* `MenuHeader`

    Heading for a menu. Composed from `MenuItem` to inherit it's styles

* `MenuDivider`

    For divided menus

* `MenuIconSize`

    This is not exported but used internally so you can set the menu size on a `Menu` and then use context to access the desired menu size for all children.

## Release Notes

Create new `Menu` component and supporting components `MenuItem`, `MenuHeader`, and `MenuDivider`.

See https://zpl.io/adX0ELe for the original designs and the storybook docs page for usage instructions and examples.

This does not include any tests because I didn't know what to test. Any tests or ideas for tests would be most welcome!