### PR TITLE
Add more font weights

### DIFF
--- a/reset.less
+++ b/reset.less
@@ -1,5 +1,5 @@
 @import (inline) "node_modules/normalize.css/normalize.css";
-@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:400,600');
+@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700|Source+Sans+Pro:400,600,700');
 
 html {
   box-sizing: border-box;


### PR DESCRIPTION
This branch adds Source Sans Pro bold (700) to the CSS reset's font import, as well as specifies regular (400) and bold weights for Source Code Pro. These font weights are needed for elements in the blog, which is using this CSS reset.