### PR TITLE
📚 Table: expand `colProps` docs to explain applicable styles

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -40,7 +40,16 @@ interface Props<RowShape> {
      * single `<colgroup>`.
      *
      * This allows you to apply styles to columns by setting a class on a single
-     * element instead of _all_ elements in a table's row
+     * element instead of _all_ elements in a table's row.
+     *
+     * Note that, per the [column
+     * spec](https://www.w3.org/TR/CSS2/tables.html#columns), there is a very
+     * limited set of style properties that can be applied to a column (via
+     * `style` or `className`):
+     * * `background`
+     * * `border`
+     * * `visiblity`
+     * * `width`
      */
     colProps?: React.DetailedHTMLProps<
       React.ColHTMLAttributes<HTMLTableColElement>,


### PR DESCRIPTION
`colProps` can affect a very specific and small number of properties;
document them so we don't forget.

Note that this is labeled as "bug fix" only because I want this to be a patch bump because I want these docs to be included in VS Code.