### PR TITLE
AR-1689 Fix crashing chromatic builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ defaults: &defaults
 jobs:
   chromatic:
     <<: *defaults
+    resource_class: medium+
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:reset": "ts-node --transpile-only build-reset.ts",
     "prebundle": "run-p icons illustrations",
     "prebuild-storybook": "npm run build",
-    "build-storybook": "node --max-old-space-size=4096 $(npm bin)/build-storybook --static-dir .storybook/public --quiet",
+    "build-storybook": "node --max-old-space-size=6144 $(npm bin)/build-storybook --static-dir .storybook/public --quiet",
     "build:github-checks": "npx ncc build .github/actions/run-circle-ci-job/index.js -o .github/actions/run-circle-ci-job/dist",
     "clean": "run-p clean:*",
     "clean:built": "ts-node --transpile-only scripts/cleanBuiltFiles.ts",


### PR DESCRIPTION
Chromatic started crashing in CI. My instincts tell me it's a memory issue since we've seen this in the past. Use a larger container class and notify node that it can use 6GB of memory instead of 4.

Resolves [AR-1689](https://apollographql.atlassian.net/browse/AR-1689)

---

This is a stopgap solution until we update to Storybook v6 which supposedly resolves the bug causing such high memory usage https://github.com/storybookjs/storybook/issues/7743. I spent an hour unsuccessfully trying to upgrade to the latest beta. This will have to hold us over.