### PR TITLE
Add Midnight color palette to SpaceKit

### DIFF
--- a/src/colors/colors.ts
+++ b/src/colors/colors.ts
@@ -136,6 +136,16 @@ export const colors = {
     lightest: "#E6EBFF",
   },
 
+  midnight: {
+    darkest: "#060F2F",
+    darker: "#1B2240",
+    dark: "#383D5B",
+    base: "#3D4B6A",
+    light: "#566992",
+    lighter: "#798FBB",
+    lightest: "#B4C3DB",
+  },
+
   white: "#ffffff",
 } as const;
 
@@ -163,7 +173,8 @@ export type ShadedColor =
   | typeof colors["orange"][keyof typeof colors["orange"]]
   | typeof colors["yellow"][keyof typeof colors["yellow"]]
   | typeof colors["purple"][keyof typeof colors["purple"]]
-  | typeof colors["blilet"][keyof typeof colors["blilet"]];
+  | typeof colors["blilet"][keyof typeof colors["blilet"]]
+  | typeof colors["midnight"][keyof typeof colors["midnight"]];
 
 /**
  * Represents all colors available in Space Kit

--- a/stories/Color.metadata.js
+++ b/stories/Color.metadata.js
@@ -445,6 +445,41 @@ const blilet = {
   },
 };
 
+const midnight = {
+  title: "Midnight",
+  options: {
+    darkest: {
+      text: 1,
+      flags: [1, 1, 0, 0],
+    },
+    darker: {
+      text: 1,
+      flags: [1, 1, 0, 0],
+    },
+    dark: {
+      text: 1,
+      flags: [1, 1, 0, 0],
+    },
+    base: {
+      flag: "base",
+      text: 1,
+      flags: [1, 1, 0, 0],
+    },
+    light: {
+      text: 1,
+      flags: [1, 1, 0, 1],
+    },
+    lighter: {
+      text: 0,
+      flags: [0, 1, 1, 1],
+    },
+    lightest: {
+      text: 0,
+      flags: [0, 0, 1, 1],
+    },
+  },
+};
+
 module.exports = {
   // brand colors
   pink,
@@ -463,4 +498,5 @@ module.exports = {
   yellow,
   purple,
   blilet,
+  midnight,
 };

--- a/stories/Color.stories.js
+++ b/stories/Color.stories.js
@@ -55,6 +55,6 @@ storiesOf("Color", module)
     <ColorStory
       title="Alternate Colors"
       description="The alternate colors are rounding out the set of colors we have in the system, but will likely not be used that often. A common use case for these colors will be data visualizations."
-      array={["orange", "yellow", "purple", "blilet"]}
+      array={["orange", "yellow", "purple", "blilet", "midnight"]}
     />
   ));


### PR DESCRIPTION
This PR adds the midnight color palette to SpaceKit for use as a dark mode theme color base. 🌃 

| Preview |
|---|
|![image](https://user-images.githubusercontent.com/1319791/83811821-5cfebb00-a66f-11ea-8457-2204e3d58040.png)|
