### PR TITLE
Add history and left/right/down/up double arrow icons

### DIFF
--- a/src/icons/svgs/controls/icon-double-arrow-down.svg
+++ b/src/icons/svgs/controls/icon-double-arrow-down.svg
@@ -1,0 +1,9 @@
+<svg width="26px" height="25px" viewBox="0 0 26 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon-chevron-down</title>
+    <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" transform="translate(-776.000000, -628.000000)" stroke="#000000" stroke-width="1.5">
+        <g transform="translate(789.000000, 640.500000) scale(1, -1) rotate(-90.000000) translate(-789.000000, -640.500000) translate(778.000000, 629.000000)">
+            <path d="M11.15332,22.3066 L21.7816,11.67836 C22.072,11.38886 22.072,10.91792 21.7826,10.62842 L21.7816,10.62744 L11.15332,-0.000846"></path>
+            <path d="M0,22.3066 L10.62828,11.67836 C10.91878,11.38886 10.91878,10.91792 10.62928,10.62842 L10.62828,10.62744 L0,-0.000846"></path>
+        </g>
+    </g>
+</svg>

--- a/src/icons/svgs/controls/icon-double-arrow-left.svg
+++ b/src/icons/svgs/controls/icon-double-arrow-left.svg
@@ -1,0 +1,9 @@
+<svg width="24px" height="25px" viewBox="0 0 24 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon-chevron-left</title>
+    <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" transform="translate(-777.000000, -681.000000)" stroke="#000000" stroke-width="1.5">
+        <g transform="translate(789.000000, 693.500000) scale(1, -1) rotate(-180.000000) translate(-789.000000, -693.500000) translate(778.000000, 682.000000)">
+            <path d="M11.15332,22.3066 L21.7816,11.67836 C22.072,11.38886 22.072,10.91792 21.7826,10.62842 L21.7816,10.62744 L11.15332,-0.000846"></path>
+            <path d="M0,22.3066 L10.62828,11.67836 C10.91878,11.38886 10.91878,10.91792 10.62928,10.62842 L10.62828,10.62744 L0,-0.000846"></path>
+        </g>
+    </g>
+</svg>

--- a/src/icons/svgs/controls/icon-double-arrow-right.svg
+++ b/src/icons/svgs/controls/icon-double-arrow-right.svg
@@ -1,0 +1,9 @@
+<svg width="24px" height="25px" viewBox="0 0 24 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon-chevron-right</title>
+    <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" transform="translate(-777.000000, -732.000000)" stroke="#000000" stroke-width="1.5">
+        <g transform="translate(789.000000, 744.500000) scale(-1, -1) rotate(-180.000000) translate(-789.000000, -744.500000) translate(778.000000, 733.000000)">
+            <path d="M11.15332,22.3066 L21.7816,11.67836 C22.072,11.38886 22.072,10.91792 21.7826,10.62842 L21.7816,10.62744 L11.15332,-0.000846"></path>
+            <path d="M0,22.3066 L10.62828,11.67836 C10.91878,11.38886 10.91878,10.91792 10.62928,10.62842 L10.62828,10.62744 L0,-0.000846"></path>
+        </g>    
+    </g>
+</svg>

--- a/src/icons/svgs/controls/icon-double-arrow-up.svg
+++ b/src/icons/svgs/controls/icon-double-arrow-up.svg
@@ -1,0 +1,9 @@
+<svg width="26px" height="25px" viewBox="0 0 26 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon-chevron-up</title>
+    <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" transform="translate(-776.000000, -579.000000)" stroke="#000000" stroke-width="1.5">
+        <g transform="translate(789.000000, 591.500000) rotate(-90.000000) translate(-789.000000, -591.500000) translate(778.000000, 580.000000)">
+            <path d="M11.15332,22.3066 L21.7816,11.67836 C22.072,11.38886 22.072,10.91792 21.7826,10.62842 L21.7816,10.62744 L11.15332,-0.000846"></path>
+            <path d="M0,22.3066 L10.62828,11.67836 C10.91878,11.38886 10.91878,10.91792 10.62928,10.62842 L10.62828,10.62744 L0,-0.000846"></path>
+        </g>
+    </g>
+</svg>

--- a/src/icons/svgs/essentials/icon-history.svg
+++ b/src/icons/svgs/essentials/icon-history.svg
@@ -1,0 +1,8 @@
+<svg width="26px" height="24px" viewBox="0 0 26 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round" stroke="#000000" strokeWidth="1.5" transform="translate(1.000000, 1.000000)">
+      <polyline transform="translate(4.000000, 4.500000) rotate(-315.000000) translate(-4.000000, -4.500000)" points="1 3 4 6 7 3" />
+      <path d="M2,11 C2,17.0751322 6.92486775,22 13,22 C19.0751322,22 24,17.0751322 24,11 C24,4.92486775 19.0751322,0 13,0 C8.96639642,0 5.4398684,2.17104851 3.52521611,5.40834533" />
+      <line x1="16.1819805" y1="14.1819805" x2="13" y2="11" />
+      <line x1="13" y1="4.5" x2="13" y2="11" />
+    </g>
+</svg>


### PR DESCRIPTION
Adds double arrow icons for left, right, down, and up 
![image](https://user-images.githubusercontent.com/3953093/83894609-837c2f00-a71f-11ea-8600-9927fed1fe3e.png)

Adds the history icon
![image](https://user-images.githubusercontent.com/3953093/83894637-8a0aa680-a71f-11ea-81b5-757be550b864.png)
