### PR TITLE
Update AlertCard dark theme to use midnight tones

### DIFF
--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -97,7 +97,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
           theme === "light"
             ? colors.white
             : theme === "dark"
-            ? colors.black.lighter
+            ? colors.midnight.darker
             : assertUnreachable(theme),
         color:
           theme === "light"
@@ -192,7 +192,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
               theme === "light"
                 ? colors.silver.dark
                 : theme === "dark"
-                ? colors.grey.dark
+                ? colors.midnight.base
                 : assertUnreachable(theme),
             marginTop: 14,
             marginBottom: 14,

--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -175,7 +175,12 @@ export const AlertCard: React.FC<AlertCardProps> = ({
         <IconClose
           onClick={onClose}
           css={{
-            color: colors.grey.lighter,
+            color:
+              theme === "light"
+                ? colors.grey.lighter
+                : theme === "dark"
+                ? colors.midnight.lighter
+                : assertUnreachable(theme),
             cursor: "pointer",
             width: 10,
             height: 10,


### PR DESCRIPTION
This PR updates the AlertCard component's dark theme to use the midnight tones recently added.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1319791/84982292-3dde3f80-b0eb-11ea-9324-cf7da84cb107.png) | ![image](https://user-images.githubusercontent.com/1319791/84982318-4b93c500-b0eb-11ea-9b67-d231c474df83.png) |
| ![image](https://user-images.githubusercontent.com/1319791/84982348-60705880-b0eb-11ea-9014-17c364bdb7d3.png) | ![image](https://user-images.githubusercontent.com/1319791/84982375-6ebe7480-b0eb-11ea-9ae4-0a40043daced.png) |
| ![image](https://user-images.githubusercontent.com/1319791/84982420-87c72580-b0eb-11ea-94ff-0bb0427faf9f.png) | ![image](https://user-images.githubusercontent.com/1319791/84982444-91e92400-b0eb-11ea-9492-7c8698a6c300.png) |
| ![image](https://user-images.githubusercontent.com/1319791/84982467-a0374000-b0eb-11ea-862f-2c9e0990132b.png) | ![image](https://user-images.githubusercontent.com/1319791/84982494-b218e300-b0eb-11ea-9ee5-65a5e5f1155c.png) |
| ![image](https://user-images.githubusercontent.com/1319791/84982508-be04a500-b0eb-11ea-8914-3055ffb4c2d7.png) | ![image](https://user-images.githubusercontent.com/1319791/84982524-c826a380-b0eb-11ea-98db-dbd1177ba2d1.png) |