### PR TITLE
darken spinner trail by 1 shade

### DIFF
--- a/src/Loaders/LoadingSpinner.tsx
+++ b/src/Loaders/LoadingSpinner.tsx
@@ -53,7 +53,7 @@ export const LoadingSpinner = React.forwardRef<SVGSVGElement, Props>(
       }
     > = {
       light: {
-        orbitColor: colors.silver.light,
+        orbitColor: colors.silver.base,
         orbitOpacity: 1,
         asteroidColor: colors.blue.base,
       },


### PR DESCRIPTION
Pages in Studio now have grey-light backgrounds, and the orbit blends in to the background
![download](https://user-images.githubusercontent.com/743976/85807376-bc586400-b71f-11ea-8b7a-61c9b4757c43.gif)


Making the orbit a shade darker for the "light" theme would solve this problem

It does change the orbit trail color for an existing theme so it's a breaking change; however this seemed more pragmatic than creating a different theme name to call this

Longer term if we revist the component's api, we should consider passing the 2 colors we're using in via props (e.g. fgColor, bgColor) so we would require a version bump and package update to change colors (cui bono?)