### PR TITLE
Remove drop shadow from AlertBanner

### DIFF
--- a/src/AlertBanner/AlertBanner.story.mdx
+++ b/src/AlertBanner/AlertBanner.story.mdx
@@ -73,13 +73,13 @@ import {
   <Story name="success light">
     <AlertBanner type="success">
       This is an example of an inline error message. It should be rather short,
-      but can have multi-lines if needed. Learn more
+      but can have multi-lines if needed.
     </AlertBanner>
   </Story>
   <Story name="success dark">
     <AlertBanner type="success" theme="dark">
       This is an example of an inline error message. It should be rather short,
-      but can have multi-lines if needed. Learn more
+      but can have multi-lines if needed.
     </AlertBanner>
   </Story>
 </Preview>

--- a/src/AlertBanner/AlertBanner.tsx
+++ b/src/AlertBanner/AlertBanner.tsx
@@ -71,7 +71,6 @@ export const AlertBanner: React.FC<AlertBannerProps> = ({
               borderColor: colors.silver.dark,
             }
           : assertUnreachable(theme)),
-        boxShadow: `0 4px 8px 0 rgba(0, 0, 0, .04)`,
         borderStyle: "solid",
         borderRadius: 4,
         padding: "12px 15px",


### PR DESCRIPTION
I started from the AlertCard and forgot to remove the drop shadow.
This removes the drop shadow and updates the copy in the story a little bit. 