### PR TITLE
🚧 add debugging to Tooltip/Confirmation stories

### DIFF
--- a/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
+++ b/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
@@ -5,23 +5,26 @@ import { ConfirmationTooltip } from "../ConfirmationTooltip";
 import { findByText } from "@testing-library/dom";
 import { PerformUserInteraction } from "../shared/PerformUserInteraction";
 import { storiesOf } from "@storybook/react";
+import { DebugTooltip } from "../shared/DebugTooltip";
 
 storiesOf("ConfirmationTooltip", module)
   .add(
     "forced visible",
     () => {
       return (
-        <PerformUserInteraction
-          callback={async () => {
-            userEvent.click(await findByText(document.body, "click"));
-          }}
-        >
-          <div style={{ padding: 50 }}>
-            <ConfirmationTooltip content="default content">
-              <Button>click</Button>
-            </ConfirmationTooltip>
-          </div>
-        </PerformUserInteraction>
+        <DebugTooltip>
+          <PerformUserInteraction
+            callback={async () => {
+              userEvent.click(await findByText(document.body, "click"));
+            }}
+          >
+            <div style={{ padding: 50 }}>
+              <ConfirmationTooltip content="default content">
+                <Button>click</Button>
+              </ConfirmationTooltip>
+            </div>
+          </PerformUserInteraction>
+        </DebugTooltip>
       );
     },
     {

--- a/src/Tooltip/Tooltip.story.tsx
+++ b/src/Tooltip/Tooltip.story.tsx
@@ -6,6 +6,7 @@ import { colors } from "../colors";
 import { PerformUserInteraction } from "../shared/PerformUserInteraction";
 import userEvent from "@testing-library/user-event";
 import { findByRole } from "@testing-library/dom";
+import { DebugTooltip } from "../shared/DebugTooltip";
 
 storiesOf("Tooltip", module)
   .add("live", () => {
@@ -40,79 +41,79 @@ storiesOf("Tooltip", module)
     "normal padding",
     () => {
       return (
-        <PerformUserInteraction
-          callback={async () => {
-            userEvent.click(await findByRole(document.body, "button"));
-          }}
-        >
-          <div
-            style={{
-              alignItems: "center",
-              border: `1px solid ${colors.silver.light}`,
-              borderRadius: ".25rem",
-              display: "flex",
-              height: 150,
-              justifyContent: "center",
-              width: 149,
+        <DebugTooltip>
+          <PerformUserInteraction
+            callback={async () => {
+              userEvent.click(await findByRole(document.body, "button"));
             }}
           >
-            <Tooltip content="hover">
-              <Button>hover</Button>
-            </Tooltip>
-          </div>
-        </PerformUserInteraction>
+            <div
+              style={{
+                alignItems: "center",
+                border: `1px solid ${colors.silver.light}`,
+                borderRadius: ".25rem",
+                display: "flex",
+                height: 150,
+                justifyContent: "center",
+                width: 149,
+              }}
+            >
+              <Tooltip content="hover">
+                <Button>hover</Button>
+              </Tooltip>
+            </div>
+          </PerformUserInteraction>
+        </DebugTooltip>
       );
     },
-    {
-      chromatic: { delay: 500 },
-    }
+    { chromatic: { delay: 500 } }
   )
   .add(
     "relaxed padding",
     () => {
       return (
-        <PerformUserInteraction
-          callback={async () => {
-            userEvent.click(await findByRole(document.body, "button"));
-          }}
-        >
-          <div
-            style={{
-              alignItems: "flex-start",
-              border: `1px solid ${colors.silver.light}`,
-              borderRadius: ".25rem",
-              display: "flex",
-              height: 200,
-              justifyContent: "center",
-              width: 400,
+        <DebugTooltip>
+          <PerformUserInteraction
+            callback={async () => {
+              userEvent.click(await findByRole(document.body, "button"));
             }}
           >
-            <Tooltip
-              content={
-                <>
-                  <div style={{ fontWeight: 700, marginBottom: 8 }}>
-                    Our No-worries Billing Policy
-                  </div>
-                  <div>
-                    We give you a preview of how many users have been added to
-                    your organization, so you can make changes if someone
-                    shouldn’t have access to your data or were added by mistake.
-                    Simply remove them before you’re billed and you won’t be
-                    charged.
-                  </div>
-                </>
-              }
-              padding="relaxed"
+            <div
+              style={{
+                alignItems: "flex-start",
+                border: `1px solid ${colors.silver.light}`,
+                borderRadius: ".25rem",
+                display: "flex",
+                height: 200,
+                justifyContent: "center",
+                width: 400,
+              }}
             >
-              <Button>hover</Button>
-            </Tooltip>
-          </div>
-        </PerformUserInteraction>
+              <Tooltip
+                content={
+                  <>
+                    <div style={{ fontWeight: 700, marginBottom: 8 }}>
+                      Our No-worries Billing Policy
+                    </div>
+                    <div>
+                      We give you a preview of how many users have been added to
+                      your organization, so you can make changes if someone
+                      shouldn’t have access to your data or were added by
+                      mistake. Simply remove them before you’re billed and you
+                      won’t be charged.
+                    </div>
+                  </>
+                }
+                padding="relaxed"
+              >
+                <Button>hover</Button>
+              </Tooltip>
+            </div>
+          </PerformUserInteraction>
+        </DebugTooltip>
       );
     },
-    {
-      chromatic: { delay: 500 },
-    }
+    { chromatic: { delay: 500 } }
   )
   .add(
     "disabled, no tooltip should be visible",
@@ -141,7 +142,5 @@ storiesOf("Tooltip", module)
         </PerformUserInteraction>
       );
     },
-    {
-      chromatic: { delay: 500 },
-    }
+    { chromatic: { delay: 500 } }
   );

--- a/src/shared/DebugTooltip.tsx
+++ b/src/shared/DebugTooltip.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { PerformUserInteraction } from "../shared/PerformUserInteraction";
+import { getByTestId, waitFor } from "@testing-library/dom";
+
+/**
+ * Component wrapping a Tooltip to debug it's positioning issues. This should be
+ * stripped out when we figure out why we keep having off-by-one pixel issues.
+ */
+export const DebugTooltip: React.FC = ({ children }) => {
+  return (
+    <PerformUserInteraction
+      callback={async () => {
+        const tippyRoot = await waitFor(() => {
+          const element = document.querySelector<HTMLDivElement>(
+            "*[data-tippy-root]"
+          );
+          if (!element) throw new TypeError("could not find tippy root");
+          return element;
+        });
+
+        getByTestId(document.body, "debug-styles-box").appendChild(
+          document.createTextNode(tippyRoot.style.transform)
+        );
+      }}
+    >
+      <div style={{ width: 300, height: 250, position: "relative" }}>
+        {children}
+
+        <pre
+          style={{
+            bottom: 5,
+            fontSize: 10,
+            left: 5,
+            padding: 5,
+            position: "absolute",
+            right: 5,
+          }}
+          className="chromatic-ignore"
+          data-testid="debug-styles-box"
+        />
+      </div>
+    </PerformUserInteraction>
+  );
+};


### PR DESCRIPTION
Try to figure out why they are flip flopping by adding the positioning information to the storybook output so we can look at the actual calculation values.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.2-canary.207.6724.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.3.2-canary.207.6724.0
  # or 
  yarn add @apollo/space-kit@8.3.2-canary.207.6724.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
