### PR TITLE
AR-1781 Don't render `Tooltip`, `ConfirmationTooltip`, or `Popover` if `content` prop is `undefined`

### DIFF
--- a/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
+++ b/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
@@ -28,6 +28,27 @@ storiesOf("ConfirmationTooltip", module)
       chromatic: { delay: 500 },
     }
   )
+  .add(
+    "disabled, no confirmation should be visible",
+    () => {
+      return (
+        <PerformUserInteraction
+          callback={async () => {
+            userEvent.click(await findByText(document.body, "click"));
+          }}
+        >
+          <div style={{ padding: 50 }}>
+            <ConfirmationTooltip content="content" disabled>
+              <Button>click</Button>
+            </ConfirmationTooltip>
+          </div>
+        </PerformUserInteraction>
+      );
+    },
+    {
+      chromatic: { delay: 500 },
+    }
+  )
   .add("interactive", () => {
     return (
       <div style={{ padding: 50 }}>

--- a/src/ConfirmationTooltip/index.tsx
+++ b/src/ConfirmationTooltip/index.tsx
@@ -4,7 +4,7 @@ import { AbstractTooltip, AbstractTooltipProps } from "../AbstractTooltip";
 
 type Props = Pick<
   React.ComponentProps<typeof AbstractTooltip>,
-  "children" | "content"
+  "children" | "content" | "disabled"
 > &
   AbstractTooltipProps;
 

--- a/src/Popover/PopoverTests.story.jsx
+++ b/src/Popover/PopoverTests.story.jsx
@@ -173,6 +173,39 @@ storiesOf("Tests|Popover", module)
         />
       </PerformUserInteraction>
     </div>
+  ))
+  .add("with disabled prop, nothing should appear", () => (
+    <div
+      className="sk-scroll-container"
+      style={{
+        height: 165,
+        width: 210,
+        border: `1px solid ${colors.blue.base}`,
+        overflow: "hidden",
+        position: "relative",
+      }}
+    >
+      <PerformUserInteraction
+        callback={async () => {
+          userEvent.click(await findByRole(document.body, "button"));
+        }}
+      >
+        <Popover
+          disabled
+          popperOptions={{ strategy: "absolute" }}
+          placement="bottom-start"
+          fallbackPlacements={["top-start"]}
+          iconSize="small"
+          maxWidth={280}
+          content="content"
+          trigger={
+            <Button style={{ position: "absolute", left: 0, top: 0 }}>
+              Open Popover
+            </Button>
+          }
+        />
+      </PerformUserInteraction>
+    </div>
   ));
 
 storiesOf("Tests|ListItem", module)

--- a/src/Popover/index.tsx
+++ b/src/Popover/index.tsx
@@ -8,6 +8,7 @@ interface Props
     React.ComponentProps<typeof AbstractTooltip>,
     | "children"
     | "content"
+    | "disabled"
     | "maxWidth"
     | "placement"
     | "fallbackPlacements"

--- a/src/Tooltip/Tooltip.story.tsx
+++ b/src/Tooltip/Tooltip.story.tsx
@@ -113,4 +113,35 @@ storiesOf("Tooltip", module)
     {
       chromatic: { delay: 500 },
     }
+  )
+  .add(
+    "disabled, no tooltip should be visible",
+    () => {
+      return (
+        <PerformUserInteraction
+          callback={async () => {
+            userEvent.click(await findByRole(document.body, "button"));
+          }}
+        >
+          <div
+            style={{
+              alignItems: "center",
+              border: `1px solid ${colors.silver.light}`,
+              borderRadius: ".25rem",
+              display: "flex",
+              height: 150,
+              justifyContent: "center",
+              width: 149,
+            }}
+          >
+            <Tooltip content="tooltip" disabled>
+              <Button>tooltip</Button>
+            </Tooltip>
+          </div>
+        </PerformUserInteraction>
+      );
+    },
+    {
+      chromatic: { delay: 500 },
+    }
   );

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -4,7 +4,12 @@ import { AbstractTooltip, AbstractTooltipProps } from "../AbstractTooltip";
 
 type Props = Pick<
   React.ComponentProps<typeof AbstractTooltip>,
-  "children" | "content" | "interactive" | "className" | "placement"
+  | "children"
+  | "content"
+  | "disabled"
+  | "interactive"
+  | "className"
+  | "placement"
 > &
   AbstractTooltipProps;
 


### PR DESCRIPTION
Resolves issue [AR-1781](https://apollographql.atlassian.net/browse/AP-1781)