### PR TITLE
AR-1818 Modal: Make `as` prop propogate `ref`

### DIFF
--- a/src/Modal/Modal.spec.tsx
+++ b/src/Modal/Modal.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Modal } from "./Modal";
 import { Button } from "../Button";
@@ -209,4 +209,20 @@ test("when passed `containerAs` prop, props should be merged", () => {
   expect(getByTestId(testId)).toHaveClass(className);
   expect(getByTestId(testId).localName).toBe("span");
   expect(getByTestId(testId)).toHaveStyle("font-weight: bold");
+});
+
+test("when `as` includes a `ref`, `ref` is propagated", () => {
+  const ref = React.createRef<HTMLFormElement>();
+
+  render(
+    <Modal
+      as={<form data-testid="form" ref={ref} />}
+      size="medium"
+      title="title"
+    >
+      content
+    </Modal>
+  );
+
+  expect(ref.current).toBe(screen.getByTestId("form"));
 });

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/ban-ts-ignore */
 /** @jsx jsx */
 import { jsx, css, ClassNames } from "@emotion/core";
 import React, { useEffect } from "react";
-import { motion } from "framer-motion";
+import { motion, MotionProps } from "framer-motion";
 import * as typography from "../typography";
 import { colors } from "../colors";
 import * as CSS from "csstype";
@@ -172,15 +171,18 @@ export const Modal: React.FC<Props> = ({
 
   /**
    * Framer motion component to render. The type will be taken from the `as`
-   * prop
+   * prop.
+   *
+   * We have to strip the type because we'll get an error about the union being
+   * too complex to model because `motion` has over 100 options.
    */
-  const MotionComponent = motion[type];
+  const MotionComponent: React.ComponentType<MotionProps> = motion[type];
 
   return (
     <ClassNames>
       {({ css, cx }) => {
-        return React.createElement(
-          containerAs.type,
+        return React.cloneElement(
+          containerAs,
           {
             onClick: onClose,
             ...containerAs.props,
@@ -188,6 +190,7 @@ export const Modal: React.FC<Props> = ({
           },
           <MotionComponent
             {...as.props}
+            ref={(as as any).ref}
             animate={{ opacity: 1, scale: 1 }}
             initial={disableAnimations ? false : { opacity: 0, scale: 0.9 }}
             transition={{
@@ -199,18 +202,11 @@ export const Modal: React.FC<Props> = ({
                 velocity: 8,
               },
             }}
-            onClick={
-              // Ignore the type of `event` because the React.MouseEvent
-              // generic will be a union of 170 different DOM elements;
-              // TypeScript can't handle that.
-              //
-              // @ts-ignore
-              (event: React.MouseEvent<any>) => {
-                event.stopPropagation();
+            onClick={(event: React.MouseEvent<any>) => {
+              event.stopPropagation();
 
-                as.props.onClick?.(event);
-              }
-            }
+              as.props.onClick?.(event);
+            }}
             className={cx(
               css(
                 {


### PR DESCRIPTION
Resolves issue [AR-1818](https://apollographql.atlassian.net/browse/AP-1818)

Modals didn't take `as` prop's `ref`, now it does. We had to strip some type safety that we weren't actually using, which is fine.

Also adds a test to make sure this works 😃 