### PR TITLE
Fix Card bottom margin with falsey children

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -61,7 +61,17 @@ export const Card: React.FC<CardProps> = ({
       paddingBottom: size === "large" ? 16 : 28,
     }}
   >
-    <div css={{ display: "flex", marginBottom: children ? 24 : 0 }}>
+    <div
+      css={{
+        display: "flex",
+        marginBottom:
+          !children ||
+          (Array.isArray(children) &&
+            children.filter((child) => !!child).length === 0)
+            ? 0
+            : 24,
+      }}
+    >
       <div
         css={{
           flex: "1 1 0%",

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -64,12 +64,7 @@ export const Card: React.FC<CardProps> = ({
     <div
       css={{
         display: "flex",
-        marginBottom:
-          !children ||
-          (Array.isArray(children) &&
-            children.filter((child) => !!child).length === 0)
-            ? 0
-            : 24,
+        marginBottom: React.Children.toArray(children).some(Boolean) ? 24 : 0
       }}
     >
       <div

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -64,7 +64,7 @@ export const Card: React.FC<CardProps> = ({
     <div
       css={{
         display: "flex",
-        marginBottom: React.Children.toArray(children).some(Boolean) ? 24 : 0
+        marginBottom: React.Children.toArray(children).some(Boolean) ? 24 : 0,
       }}
     >
       <div


### PR DESCRIPTION
When a card has multiple children that end up falsey, or an empty list of children this would previously add a padding to the bottom of the card. We should only add the padding if there are non falsey children