### PR TITLE
Add relative to label so VisuallyHidden is inside instead of under it

### DIFF
--- a/src/Switch/index.tsx
+++ b/src/Switch/index.tsx
@@ -98,6 +98,7 @@ export const Switch: React.FC<SwitchProps> & { Label: typeof Label } = ({
           className={cx(
             css({
               opacity: props.isDisabled ? 0.5 : undefined,
+              position: "relative",
             }),
             className
           )}


### PR DESCRIPTION
Browser tries to scroll to input, but VisuallyHidden was way off screen. Thing makes the container relative so that the input is positioned inside. 

Fixes this UI bug
![image](https://user-images.githubusercontent.com/3953093/91906402-1e7c9a80-ec76-11ea-88e1-5b1bfb50060a.png)
