### PR TITLE
`AlertBanner`: wrap `children` in customizable `childrenContainerAs` element

### DIFF
--- a/src/AlertBanner/AlertBanner.spec.tsx
+++ b/src/AlertBanner/AlertBanner.spec.tsx
@@ -1,0 +1,29 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { AlertBanner } from "./AlertBanner";
+import { render, screen } from "@testing-library/react";
+
+it("should render children content and icon", () => {
+  render(<AlertBanner type="info">message</AlertBanner>);
+
+  expect(screen.getByText("message")).toBeInTheDocument();
+  expect(document.querySelector("svg")).toBeInTheDocument();
+});
+
+it("should render the default `childrenContainerAs` element", () => {
+  render(<AlertBanner type="info">message</AlertBanner>);
+  expect(screen.getByText("message")).toHaveProperty("tagName", "DIV");
+});
+
+it("should render a custom `childrenContainerAs` element", () => {
+  render(
+    <AlertBanner
+      type="info"
+      childrenContainerAs={<p data-testid="containerAs" />}
+    >
+      message
+    </AlertBanner>
+  );
+  expect(screen.getByTestId("containerAs")).toBeInTheDocument();
+  expect(screen.getByTestId("containerAs")).toHaveProperty("tagName", "P");
+});

--- a/src/AlertBanner/AlertBanner.tsx
+++ b/src/AlertBanner/AlertBanner.tsx
@@ -23,6 +23,16 @@ interface AlertBannerProps {
    */
   children?: React.ReactNode;
 
+  /**
+   * Override container around `{children}`. You can pass either an intrinisic
+   * jsx element as a string (like "p") or a React element (`<p />`)
+   *
+   * If you pass a React element, props that we add are spread onto the input.
+   *
+   * @default "div"
+   */
+  childrenContainerAs?: React.ReactElement | keyof JSX.IntrinsicElements;
+
   className?: string;
   style?: CSSProperties;
 
@@ -34,6 +44,7 @@ interface AlertBannerProps {
 
 export const AlertBanner: React.FC<AlertBannerProps> = ({
   children,
+  childrenContainerAs = "div",
   theme = "light",
   type,
   ...otherProps
@@ -89,13 +100,19 @@ export const AlertBanner: React.FC<AlertBannerProps> = ({
             type !== "warn" && { fill: colors.white },
         }}
       />
-      {children}
+      {React.isValidElement(childrenContainerAs)
+        ? React.cloneElement(childrenContainerAs, {}, children)
+        : React.createElement(childrenContainerAs, {}, children)}
     </section>
   );
 };
 
 AlertBanner.propTypes = {
   children: PropTypes.node,
+  childrenContainerAs: PropTypes.oneOfType([
+    PropTypes.element.isRequired,
+    PropTypes.string.isRequired as any, // Using PropTypes.string to match keyof JSX.IntrinsicElements
+  ]),
   type: PropTypes.oneOf(["info", "warn", "error", "success"] as const)
     .isRequired,
 };


### PR DESCRIPTION
## Release Notes

Children sometimes have multiple elements (like `<code>` and `ClickableText`) and will look bad because we're using flexbox to align elements to the middle. This will make sure that consumers don't have to wrap their content with a `<div />`

## Testing

I added a unit test to make sure the new element is rendered correctly and we have the storybook tests to make sure these look the same.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.14.2-canary.238.5260.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@7.14.2-canary.238.5260.0
  # or 
  yarn add @apollo/space-kit@7.14.2-canary.238.5260.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
