### PR TITLE
Fix: Set children wrapper to flex

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -266,6 +266,8 @@ export const Modal: React.FC<Props> = ({
             <div
               css={css(
                 {
+                  display: "flex",
+                  flexDirection: "column",
                   marginTop:
                     size === "large" ? 24 : size === "medium" ? 16 : 12,
                 },


### PR DESCRIPTION
# Motivation

The children wrapper does not set its own height/width. Hence, for any elements appearing inside of it, we can't use things like `height: 100%`. Being able to use this, would allow for building out simple borders and other styling.

By using `flex` and `column`s, we can change more or less no downstream dependents while making the usability of this component much more robust.

## Suggested Musical Pairing

https://www.youtube.com/watch?v=CJ68kQLS250
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.17.1-canary.242.5444.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@7.17.1-canary.242.5444.0
  # or 
  yarn add @apollo/space-kit@7.17.1-canary.242.5444.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
