### PR TITLE
Create `Select` component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,9 @@ module.exports = {
       env: {
         commonjs: true,
       },
+      rules: {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
     },
   ],
   settings: {

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tsconfig.tsbuildinfo
 /pictograms
 /Popover
 /shared
+/Select
 /SpaceKitProvider
 /Switch
 /Table

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { configure } from "@testing-library/dom";
 
 // We need to polyfill `createRange` to make JSDOM compatible with Popper. See
 // this thread https://github.com/popperjs/popper-core/issues/478 and this

--- a/package-lock.json
+++ b/package-lock.json
@@ -4215,9 +4215,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.0.tgz",
-      "integrity": "sha512-CltlJftStV4CBG4/HWVVRnBWFvLkYd22BkYO4gFgX+89JOlYiKQ5+Ji9Ovqb1o3T5DkkBn3JrVq1V/xweAaeGA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+      "integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -8839,9 +8839,9 @@
           }
         },
         "@babel/runtime": {
-          "version": "7.12.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-          "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -9007,9 +9007,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-          "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -9116,9 +9116,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-          "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -9142,9 +9142,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-          "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -9367,9 +9367,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.162",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
+      "version": "4.14.157",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
+      "integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ=="
     },
     "@types/markdown-to-jsx": {
       "version": "6.11.2",
@@ -9520,14 +9520,6 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
-          "dev": true
-        }
       }
     },
     "@types/react-color": {
@@ -10538,9 +10530,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-          "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -14965,6 +14957,11 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
+      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -16242,6 +16239,37 @@
       "dev": true,
       "requires": {
         "dotenv-defaults": "^1.0.2"
+      }
+    },
+    "downshift": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.0.6.tgz",
+      "integrity": "sha512-tmLab3cXCn6PtZYl9V8r/nB2m+7/nCNrwo0B3kTHo/2lRBHr+1en1VNOQt2wIt0ajanAnxquZ00WPCyxe6cNFQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "compute-scroll-into-view": "^1.0.14",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "duplexer": {
@@ -23542,9 +23570,9 @@
           }
         },
         "@types/prettier": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.2.tgz",
-          "integrity": "sha512-IiPhNnenzkqdSdQH3ifk9LoX7oQe61ZlDdDO4+MUv6FyWdPGDPr26gCPVs3oguZEMq//nFZZpwUZcVuNJsG+DQ==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.3.tgz",
+          "integrity": "sha512-KEHKOUP2oQyUVx8AUj42wDpHiRYMg+vinD+RNHnEvEgfSepPjuY87/g7ujt9fTYRSuueMmMkKWBplclx/H732w==",
           "dev": true
         },
         "ansi-regex": {
@@ -24143,8 +24171,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -25015,7 +25042,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -26247,8 +26273,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -28310,7 +28335,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -29307,8 +29331,7 @@
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-      "dev": true
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -32814,9 +32837,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.2.tgz",
-          "integrity": "sha512-XmrpXaTl6noDsf1dKpBuUNCOHqjs0g3jRMXf/ztRxdOmb+er8kE5z5b55Lz3p5u2T8KJ59ENBnASS8/iapVJ5g==",
+          "version": "20.2.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/tinycolor2": "^1.4.2",
     "classnames": "^2.2.6",
     "csstype": "^3.0.3",
+    "downshift": "^6.0.6",
     "lodash": "*",
     "tinycolor2": "^1.4.1",
     "tslib": "^2.0.1"
@@ -145,6 +146,7 @@
   },
   "peerDependencies": {
     "react": ">16",
+    "react-dom": ">16",
     "framer-motion": ">1.6"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,10 +61,12 @@ function CJS() {
       "@react-aria/visually-hidden",
       "@react-stately/toggle",
       "classnames",
+      "downshift",
       "framer-motion",
       "prop-types",
       "lodash/omit",
       "react",
+      "react-dom",
       "tinycolor2",
     ],
     output: [

--- a/src/AbstractTooltip/abstractTooltip/matchTriggerWidth.ts
+++ b/src/AbstractTooltip/abstractTooltip/matchTriggerWidth.ts
@@ -1,0 +1,23 @@
+import { Modifier } from "@popperjs/core";
+
+export const matchTriggerWidth: Modifier<"matchTriggerWidth", unknown> = {
+  name: "matchTriggerWidth",
+  enabled: true,
+  phase: "beforeWrite",
+  requires: ["computeStyles"],
+  requiresIfExists: ["flip", "maxSize"],
+  fn: ({ state }) => {
+    state.styles.popper.width = `${state.rects.reference.width}px`;
+  },
+  effect: ({ state }) => {
+    state.elements.popper.style.width = `${
+      (state.elements.reference as HTMLElement).offsetWidth
+    }px`;
+    const tippyBox = state.elements.popper.querySelector<HTMLElement>(
+      ".tippy-box"
+    );
+    if (tippyBox) {
+      tippyBox.style.minWidth = "0";
+    }
+  },
+};

--- a/src/AbstractTooltip/index.tsx
+++ b/src/AbstractTooltip/index.tsx
@@ -4,6 +4,7 @@ import Tippy from "@tippyjs/react";
 import { Placement } from "tippy.js";
 import { TippyStyles } from "./abstractTooltip/TippyStyles";
 import { useSpaceKitProvider } from "../SpaceKitProvider";
+import { matchTriggerWidth as matchTriggerWidthModifier } from "./abstractTooltip/matchTriggerWidth";
 import classnames from "classnames";
 
 type TippyProps = React.ComponentProps<typeof Tippy>;
@@ -27,6 +28,14 @@ export interface AbstractTooltipProps {
    * more space
    */
   padding?: "normal" | "relaxed";
+
+  /**
+   * Indicates that the popup list should match the width of the trigger
+   * compoonent
+   *
+   * @default false
+   */
+  matchTriggerWidth?: boolean;
 }
 
 type Props = TippyProps & AbstractTooltipProps;
@@ -40,6 +49,7 @@ export const AbstractTooltip: React.FC<Props> = ({
   padding = "normal",
   trigger,
   hideOnClick,
+  matchTriggerWidth = false,
   popperOptions = {},
   ...props
 }) => {
@@ -67,6 +77,10 @@ export const AbstractTooltip: React.FC<Props> = ({
               options: {
                 fallbackPlacements,
               },
+            },
+            {
+              ...matchTriggerWidthModifier,
+              enabled: matchTriggerWidth,
             },
             // This must be at the end because later modifiers override earlier
             // ones. @see

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -444,7 +444,7 @@ export const Button = React.forwardRef<HTMLElement, Props>(
                     outline: 0,
 
                     textDecoration: "none",
-
+                    textAlign: "center",
                     whiteSpace: "nowrap",
                   },
 
@@ -522,11 +522,23 @@ export const Button = React.forwardRef<HTMLElement, Props>(
                       {icon}
                     </ButtonIcon>
                   )}
-                  {children}
+
+                  {children && (
+                    <div
+                      className={css({
+                        flex: 1,
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
+                        textOverflow: "ellipsis",
+                      })}
+                    >
+                      {children}
+                    </div>
+                  )}
                   {endIcon && !loading && (
                     <ButtonIcon
                       iconSize={iconSize}
-                      className={css({ margin: iconOnly ? 0 : `0 0 0 12px` })}
+                      className={css({ margin: iconOnly ? 0 : `0 0 0 6px` })}
                     >
                       {endIcon}
                     </ButtonIcon>

--- a/src/List/List.spec.tsx
+++ b/src/List/List.spec.tsx
@@ -30,7 +30,7 @@ test("given no configuration, defaults values should be present", () => {
 
   expect(screen.getByTestId("iconSize")).toHaveTextContent(defaults.iconSize);
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
-    defaults.hoverColor
+    defaults.hoverColor ?? ""
   );
   expect(screen.getByTestId("padding")).toHaveTextContent(defaults.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
@@ -66,7 +66,7 @@ test("given nested lists with configurations in both, correct values should prop
   );
   expect(screen.getByTestId("iconSize")).toHaveTextContent(newValues.iconSize);
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
-    newValues.hoverColor
+    newValues.hoverColor ?? ""
   );
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
@@ -100,7 +100,7 @@ test("given nested lists with the top level having default configuration and the
   );
   expect(screen.getByTestId("iconSize")).toHaveTextContent(newValues.iconSize);
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
-    newValues.hoverColor
+    newValues.hoverColor ?? ""
   );
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
@@ -135,7 +135,7 @@ test("given nested lists with the top level having configuration and the child u
   );
   expect(screen.getByTestId("iconSize")).toHaveTextContent(newValues.iconSize);
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
-    newValues.hoverColor
+    newValues.hoverColor ?? ""
   );
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(

--- a/src/List/index.tsx
+++ b/src/List/index.tsx
@@ -14,35 +14,58 @@ interface Props
       "style" | "className"
     > {}
 
-export const List: React.FC<Props> = ({
-  children,
-  className,
-  style,
-  ...props
-}) => {
-  /**
-   * Combination of inherited configuration and new configuration passed via
-   * props
-   */
-  const listConfig: ReturnType<typeof useListConfig> = {
-    ...useListConfig(),
-    ...props,
-  };
+export const List = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<Props>
+>(
+  (
+    {
+      children,
+      className,
+      style,
+      endIconAs,
+      hoverColor,
+      iconSize,
+      padding,
+      selectedColor,
+      startIconAs,
+      ...props
+    },
+    ref
+  ) => {
+    /**
+     * Combination of inherited configuration and new configuration passed via
+     * props
+     */
+    const listConfig: ReturnType<typeof useListConfig> = {
+      ...useListConfig(),
+      ...(endIconAs && { endIconAs }),
+      ...(hoverColor && { hoverColor }),
+      ...(iconSize && { iconSize }),
+      ...(padding && { padding }),
+      ...(selectedColor && { selectedColor }),
+      ...(startIconAs && { startIconAs }),
+    };
 
-  const verticalMargin = -verticalListMarginFromPadding(listConfig.padding) / 2;
+    const verticalMargin =
+      -verticalListMarginFromPadding(listConfig.padding) / 2;
 
-  return (
-    <ListConfigProvider {...listConfig}>
-      <div
-        className={className}
-        style={style}
-        css={css({
-          marginTop: verticalMargin,
-          marginBottom: verticalMargin,
-        })}
-      >
-        {children}
-      </div>
-    </ListConfigProvider>
-  );
-};
+    return (
+      <ListConfigProvider {...listConfig}>
+        <div
+          {...props}
+          ref={ref}
+          className={className}
+          style={style}
+          css={css({
+            marginTop: verticalMargin,
+            marginBottom: verticalMargin,
+            outline: "none",
+          })}
+        >
+          {children}
+        </div>
+      </ListConfigProvider>
+    );
+  }
+);

--- a/src/ListConfig/index.tsx
+++ b/src/ListConfig/index.tsx
@@ -23,9 +23,10 @@ interface ListConfig {
   /**
    * Background color of the hovered item in a menu
    *
-   * The text color will be determined automatically
+   * The text color will be determined automatically. `null` indicates we don't
+   * want to show any different styling on hover.
    */
-  hoverColor: ShadedColor;
+  hoverColor: ShadedColor | null;
 
   /**
    * Icon size to use for all descendents

--- a/src/ListDivider/index.tsx
+++ b/src/ListDivider/index.tsx
@@ -7,7 +7,7 @@ import { colors } from "../colors";
 /**
  * Divider between sections in a list
  */
-export const ListDivider: React.FC = () => {
+export const ListDivider: React.FC = (props) => {
   // Stop click events so we don't try to close the list when clicking something
   // non-interactive
   const handleClick = React.useCallback<React.MouseEventHandler<HTMLHRElement>>(
@@ -20,6 +20,7 @@ export const ListDivider: React.FC = () => {
 
   return (
     <hr
+      {...props}
       onClick={handleClick}
       css={css({
         marginLeft: -8,

--- a/src/ListItem/ListItem.spec.tsx
+++ b/src/ListItem/ListItem.spec.tsx
@@ -14,7 +14,7 @@ it("given `as` prop, custom element should be rendered", () => {
 });
 
 it("given no `as` prop, ref should be passed through", () => {
-  const ref = React.createRef<HTMLElement>();
+  const ref = React.createRef<HTMLDivElement>();
 
   render(
     <ListItem data-testid="ListItem" ref={ref}>
@@ -26,7 +26,7 @@ it("given no `as` prop, ref should be passed through", () => {
 });
 
 it("given `as` prop, ref should be passed through", () => {
-  const ref = React.createRef<HTMLElement>();
+  const ref = React.createRef<HTMLDivElement>();
 
   render(
     <ListItem

--- a/src/ListItem/index.tsx
+++ b/src/ListItem/index.tsx
@@ -59,7 +59,7 @@ interface Props
         React.HTMLAttributes<HTMLDivElement>,
         HTMLDivElement
       >,
-      "className" | "onClick" | "style"
+      "className" | "onClick" | "style" | "role"
     >,
     Partial<
       Pick<ReturnType<typeof useListConfig>, "endIconAs" | "startIconAs">
@@ -82,6 +82,11 @@ interface Props
   endIcon?: React.ReactNode;
 
   /**
+   * Indicates that the `ListItem` is being highlighted
+   */
+  highlighted?: boolean;
+
+  /**
    * Indicates if this list item can be itneracted with. Defaults to `true`. If
    * set to `false`, there will be no hover effects.
    *
@@ -97,13 +102,17 @@ interface Props
   startIcon?: React.ReactNode;
 }
 
-export const ListItem = React.forwardRef<any, React.PropsWithChildren<Props>>(
+export const ListItem = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<Props>
+>(
   (
     {
       as = <div />,
       children,
       endIcon,
       endIconAs: endIconAsProp,
+      highlighted = false,
       interactive = true,
       selected = false,
       startIcon,
@@ -136,15 +145,16 @@ export const ListItem = React.forwardRef<any, React.PropsWithChildren<Props>>(
       color: selectedTextColor,
     };
 
-    const hoverStyles = interactive && {
-      backgroundColor: hoverColor,
-      color: tinycolor
-        .mostReadable(hoverColor, [colors.white, colors.grey.darker], {
-          level: "AA",
-          size: "small",
-        })
-        .toString(),
-    };
+    const highlightedStyles = hoverColor &&
+      interactive && {
+        backgroundColor: hoverColor,
+        color: tinycolor
+          .mostReadable(hoverColor, [colors.white, colors.grey.darker], {
+            level: "AA",
+            size: "small",
+          })
+          .toString(),
+      };
 
     const verticalMargin = verticalListMarginFromPadding(padding) / 2;
 
@@ -162,8 +172,9 @@ export const ListItem = React.forwardRef<any, React.PropsWithChildren<Props>>(
                     ...(selected && selectedStyles),
                     ...{ "&[aria-expanded=true]": selectedStyles },
                     ...(!selected && {
-                      "&:hover, &[data-force-hover-state]": hoverStyles,
+                      "&:hover, &[data-force-hover-state]": highlightedStyles,
                     }),
+                    ...(highlighted && !selected && highlightedStyles),
                     alignItems: "center",
                     cursor: interactive ? "pointer" : undefined,
                     borderRadius: 4,

--- a/src/Popover/PopoverTests.story.tsx
+++ b/src/Popover/PopoverTests.story.tsx
@@ -4,6 +4,7 @@ import { Button } from "../Button";
 import { findByRole } from "@testing-library/dom";
 import { Popover } from "../Popover";
 import { ListHeading } from "../ListHeading";
+import { List } from "../List";
 import { ListItem } from "../ListItem";
 import { PerformUserInteraction } from "../shared/PerformUserInteraction";
 import { storiesOf } from "@storybook/react";
@@ -30,10 +31,9 @@ storiesOf("Tests/Popover", module)
         <Popover
           placement="bottom-start"
           fallbackPlacements={["top-start"]}
-          iconSize="small"
           maxWidth={280}
           content={
-            <React.Fragment>
+            <List>
               <ListHeading>mdg-private-graphs</ListHeading>
               <ListItem>space-kit</ListItem>
               <ListItem>space-kit</ListItem>
@@ -45,7 +45,7 @@ storiesOf("Tests/Popover", module)
               <ListItem>space-kit</ListItem>
               <ListItem>space-kit</ListItem>
               <ListItem>space-kit</ListItem>
-            </React.Fragment>
+            </List>
           }
           trigger={
             <Button style={{ position: "absolute", left: 400, top: 400 }}>
@@ -76,15 +76,14 @@ storiesOf("Tests/Popover", module)
           placement="bottom"
           popperOptions={{ strategy: "absolute" }}
           fallbackPlacements={["top"]}
-          iconSize="small"
           maxWidth={280}
           content={
-            <React.Fragment>
+            <List>
               <ListHeading>Shapes</ListHeading>
               <ListItem>Circle</ListItem>
               <ListItem>Rectangle</ListItem>
               <ListItem>Square</ListItem>
-            </React.Fragment>
+            </List>
           }
           trigger={
             <Button style={{ position: "absolute", left: 0, top: 200 }}>
@@ -115,15 +114,14 @@ storiesOf("Tests/Popover", module)
           popperOptions={{ strategy: "absolute" }}
           placement="bottom"
           fallbackPlacements={["top"]}
-          iconSize="small"
           maxWidth={280}
           content={
-            <React.Fragment>
+            <List>
               <ListHeading>Shapes</ListHeading>
               <ListItem>Circle</ListItem>
               <ListItem>Rectangle</ListItem>
               <ListItem>Square</ListItem>
-            </React.Fragment>
+            </List>
           }
           trigger={
             <Button style={{ position: "absolute", left: 0, top: 200 }}>
@@ -154,7 +152,6 @@ storiesOf("Tests/Popover", module)
           popperOptions={{ strategy: "absolute" }}
           placement="bottom-start"
           fallbackPlacements={["top-start"]}
-          iconSize="small"
           maxWidth={280}
           content={
             <React.Fragment>
@@ -195,7 +192,6 @@ storiesOf("Tests/Popover", module)
           popperOptions={{ strategy: "absolute" }}
           placement="bottom-start"
           fallbackPlacements={["top-start"]}
-          iconSize="small"
           maxWidth={280}
           content="content"
           trigger={

--- a/src/Popover/index.tsx
+++ b/src/Popover/index.tsx
@@ -9,10 +9,11 @@ interface Props
     | "children"
     | "content"
     | "disabled"
+    | "fallbackPlacements"
     | "matchTriggerWidth"
     | "maxWidth"
+    | "onCreate"
     | "placement"
-    | "fallbackPlacements"
     | "popperOptions"
   > {
   className?: string;

--- a/src/Popover/index.tsx
+++ b/src/Popover/index.tsx
@@ -9,6 +9,7 @@ interface Props
     | "children"
     | "content"
     | "disabled"
+    | "matchTriggerWidth"
     | "maxWidth"
     | "placement"
     | "fallbackPlacements"

--- a/src/Select/Select.spec.tsx
+++ b/src/Select/Select.spec.tsx
@@ -1,0 +1,99 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { act, render, screen, within } from "@testing-library/react";
+import { Select } from "../Select";
+import { SpaceKitProvider } from "../SpaceKitProvider";
+
+test("given no `value`, should render `label`", () => {
+  render(
+    <SpaceKitProvider disableAnimations>
+      <Select value={null} label={<>select an item</>}>
+        <option value="a">a</option>
+        <option value="b">b</option>
+      </Select>
+    </SpaceKitProvider>
+  );
+
+  expect(
+    screen.getByRole("button", { name: "select an item" })
+  ).toBeInTheDocument();
+});
+
+test("given a `value`, should render initial value", () => {
+  render(
+    <SpaceKitProvider disableAnimations>
+      <Select value="a">
+        <option value="a">a</option>
+        <option value="b">b</option>
+      </Select>
+    </SpaceKitProvider>
+  );
+
+  expect(screen.getByText("a")).toBeInTheDocument();
+  expect(screen.queryByText("b")).not.toBeInTheDocument();
+  act(() => userEvent.click(screen.getByRole("button")));
+});
+
+test("given children mixed with `option` and `optgroup`, should render headings and elements", () => {
+  render(
+    <SpaceKitProvider disableAnimations>
+      <Select value="a">
+        <option value="a">a</option>
+        <option value="b">b</option>
+        <optgroup label="group c">
+          <option>d</option>
+          <option>e</option>
+        </optgroup>
+      </Select>
+    </SpaceKitProvider>
+  );
+
+  act(() => userEvent.click(screen.getByRole("button")));
+  expect(screen.getByRole("option", { name: "a" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "b" })).toBeInTheDocument();
+
+  const groupC = screen.getByRole("group", { name: "group c" });
+  expect(groupC).toBeInTheDocument();
+  expect(
+    within(groupC).getByRole("heading", { name: "group c" })
+  ).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "d" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "e" })).toBeInTheDocument();
+});
+
+test("when clicking button, menu shoud show", () => {
+  render(
+    <SpaceKitProvider disableAnimations>
+      <Select value="a">
+        <option value="a">a</option>
+        <option value="b">b</option>
+      </Select>
+    </SpaceKitProvider>
+  );
+
+  expect(screen.getByText("a")).toBeInTheDocument();
+  expect(screen.queryByText("b")).not.toBeInTheDocument();
+  act(() => userEvent.click(screen.getByRole("button")));
+  expect(screen.getByRole("option", { name: "a" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "b" })).toBeInTheDocument();
+});
+
+test("when clicking a select trigger in a form, form is not submitted", () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <SpaceKitProvider disableAnimations>
+      <form onSubmit={handleSubmit}>
+        <Select value="a">
+          <option value="a">a</option>
+          <option value="b">b</option>
+        </Select>
+      </form>
+    </SpaceKitProvider>
+  );
+
+  act(() => userEvent.click(screen.getByRole("button")));
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+  expect(handleSubmit).not.toHaveBeenCalled();
+});

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -1,0 +1,173 @@
+import userEvent from "@testing-library/user-event";
+import { findByRole } from "@testing-library/dom";
+import { Meta, Story, ArgsTable, Canvas } from "@storybook/addon-docs/blocks";
+import { PerformUserInteraction } from "../shared/PerformUserInteraction";
+import { Select as SpaceKitSelect } from "../Select";
+
+<Meta title="Form/Select" component={SpaceKitSelect} />
+
+export const Select = (props) => {
+  return (
+    <PerformUserInteraction
+      callback={async () => {
+        if (document.querySelector(".sbdocs")) {
+          // Do not perform interaction automatically if in Docs mode
+          return;
+        }
+        userEvent.click(await findByRole(document.body, "button"));
+      }}
+    >
+      <SpaceKitSelect {...props} />
+    </PerformUserInteraction>
+  );
+};
+
+# Select
+
+**Select** is emulates a native `select` element, but rendered with Space Kit appearances.
+
+You must use the same `<option>` and `<optgroup>` elements you would use for a native `select` element. Any nested components will not work.
+
+<Canvas>
+  <Story name="basic options">
+    <Select label="select an item">
+      <option value="value a">a</option>
+      <option value="value b">b</option>
+    </Select>
+  </Story>
+  <Story name="basic optgroup">
+    <Select label="select an item">
+      <optgroup label="Group of options">
+        <option value="value a">a</option>
+        <option value="value b">b</option>
+      </optgroup>
+      <optgroup label="Second of options">
+        <option value="value c">c</option>
+        <option value="value d">d</option>
+      </optgroup>
+    </Select>
+  </Story>
+  <Story name="disabled">
+    <Select label="disabled" disabled>
+      <option value="value a">a</option>
+      <option value="value b">b</option>
+    </Select>
+  </Story>
+</Canvas>
+
+## Control
+
+`Select` is intended to be a bare replacement for a `<select>` element. It can be either controlled or uncontrolled, see the [React: Uncontrolled Components](https://reactjs.org/docs/uncontrolled-components.html) docs for a more in-depth explanation.
+
+For controlled components, you must pass a `value` prop and have the option to pass an `onChange` prop. If you don't use an `onChange` prop, as expected, the `value` can not be changed.
+
+If you elect to use an uncontrolled component, do not pass `value` or `onChange` props. You can pass a `defaultValue` for the initial to be set and then the component will control the on it's own.
+
+## Options
+
+### Feel
+
+Selects can be displayed using any of the `feel` values from `Button`.
+
+<Canvas>
+  <Story name="feel raised">
+    <Select label="select an item" feel="raised">
+      <option>a</option>
+      <optgroup label="header 1">
+        <option>b</option>
+      </optgroup>
+    </Select>
+  </Story>
+  <Story name="feel flat">
+    <Select label="select an item" feel="flat">
+      <option>a</option>
+      <optgroup label="header 1">
+        <option>b</option>
+      </optgroup>
+    </Select>
+  </Story>
+</Canvas>
+
+### Size
+
+By default, the component will match the width of it's content. The dropdown list will also match the size of the content. There are a few presets you can use to configure the width of the select trigger and you can have the dropdown list match the width of the trigger.
+
+#### Automatic Size
+
+<Canvas>
+  <Story name="Automatic Size, Narrow">
+    <Select value="value a">
+      <option>a</option>
+    </Select>
+  </Story>
+  <Story name="Automatic Size, Wide">
+    <Select value="value this is a super long to show how wide the select will be">
+      <option>this is a super long to show how wide the select will be</option>
+    </Select>
+  </Story>
+</Canvas>
+
+#### Sizes
+
+Selects will grow and shrink with the content to up until a point (TBD)
+
+<Canvas>
+  <Story name="Small, Not Truncated">
+    <Select size="small" value="small">
+      <option>small</option>
+    </Select>
+  </Story>
+  <Story name="Small, Truncated">
+    <Select size="small" value="small truncated">
+      <option>small truncated</option>
+    </Select>
+  </Story>
+  <Story name="Medium, Not Truncated">
+    <Select size="medium" value="medium">
+      <option>medium</option>
+    </Select>
+  </Story>
+  <Story name="Medium, Truncated">
+    <Select size="medium" value="medium truncated truncated">
+      <option>medium truncated truncated</option>
+    </Select>
+  </Story>
+  <Story name="Large, Not Truncated">
+    <Select size="large" value="large">
+      <option>large</option>
+    </Select>
+  </Story>
+  <Story name="Large, Truncated">
+    <Select size="large" value="large truncated truncated">
+      <option>large truncated truncated</option>
+    </Select>
+  </Story>
+  <Story name="Extra Large, Not Truncated">
+    <Select size="extra large" value="extra large">
+      <option>extra large</option>
+    </Select>
+  </Story>
+  <Story name="Extra Large, Truncated">
+    <Select size="extra large" value="extra large truncated truncated">
+      <option>extra large truncated truncated</option>
+    </Select>
+  </Story>
+</Canvas>
+
+### Match Trigger width
+
+The menu width can be fixed to match the trigger button size with the `matchTriggerWidth` prop. This is most useful when you yourself define the size of the select element.
+
+<Canvas>
+  <Story name="Match Trigger Prop">
+    <Select value="small" matchTriggerWidth style={{ width: 150 }}>
+      <option>small</option>
+      <option>medium</option>
+      <option>large</option>
+    </Select>
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Select} />

--- a/src/Select/SelectTests.story.tsx
+++ b/src/Select/SelectTests.story.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { findByRole } from "@testing-library/dom";
+import { Select } from "../Select";
+import { PerformUserInteraction } from "../shared/PerformUserInteraction";
+import { storiesOf } from "@storybook/react";
+
+storiesOf("Tests/Select", module)
+  .addParameters({ component: Select })
+  .add(
+    "initially selected item should scroll into view on mount",
+    () => (
+      <div
+        className="sk-scroll-container"
+        style={{
+          height: 300,
+          width: 300,
+          border: "1px solid red",
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        <PerformUserInteraction
+          callback={async () => {
+            // Click the triggering button
+            userEvent.click(await findByRole(document.body, "button"));
+          }}
+        >
+          <Select value="k" popperOptions={{ strategy: "absolute" }}>
+            <option>a</option>
+            <option>b</option>
+            <option>c</option>
+            <option>d</option>
+            <option>e</option>
+            <option>f</option>
+            <option>g</option>
+            <option>h</option>
+            <option>i</option>
+            <option>j</option>
+            <option>k</option>
+          </Select>
+        </PerformUserInteraction>
+      </div>
+    ),
+    {
+      chromatic: { delay: 200 },
+    }
+  );

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -1,0 +1,339 @@
+import React, { ChangeEvent } from "react";
+import { Button } from "../Button";
+import { colors } from "../colors";
+import { IconArrowDown } from "../icons/IconArrowDown";
+import { List } from "../List";
+import { ListItem } from "../ListItem";
+import { ListHeading } from "../ListHeading";
+import { ListDivider } from "../ListDivider";
+import { Popover } from "../Popover";
+import { useSelect, UseSelectPropGetters } from "downshift";
+import { ClassNames } from "@emotion/core";
+import {
+  reactNodeToDownshiftItems,
+  isHTMLOptionElement,
+  isHTMLOptgroupElement,
+} from "./select/reactNodeToDownshiftItems";
+import { ListConfigProvider, useListConfig } from "../ListConfig";
+
+export type OptionProps = Omit<
+  React.DetailedHTMLProps<
+    React.OptionHTMLAttributes<HTMLOptionElement>,
+    HTMLOptionElement
+  >,
+  "children"
+> & { children: string };
+interface ListItemWrapperProps {
+  /** `items` prop passed to `useSelect`
+   *
+   * We'll use this to get the index
+   */
+  downshiftItems: OptionProps[];
+  element: React.ReactElement<OptionProps, "option">;
+  /** Passthrough downshift function to get the props for an item */
+  getItemProps: UseSelectPropGetters<OptionProps>["getItemProps"];
+}
+
+/**
+ * Abstraction to handle rendering `ListItem`s with downshift props
+ */
+const ListItemWrapper: React.FC<ListItemWrapperProps> = ({
+  downshiftItems,
+  element,
+  getItemProps,
+}) => {
+  const index = downshiftItems.indexOf(element.props);
+
+  if (index === -1) {
+    throw new Error(
+      "Development error: props must be passed by reference in `reactNodeToDownshiftItems` so they can be found with `Array.prototype.indexOf`"
+    );
+  }
+
+  const downshiftItemProps = getItemProps({
+    item: element.props,
+    index: downshiftItems.indexOf(element.props),
+  });
+
+  return (
+    <ListItem
+      key={element.props.value || element.props.children}
+      {...downshiftItemProps}
+      selected={downshiftItemProps["aria-selected"] === "true"}
+    >
+      {element.props.children}
+    </ListItem>
+  );
+};
+
+interface Props
+  extends Pick<
+      React.ComponentProps<typeof Popover>,
+      | "disabled"
+      | "maxWidth"
+      | "placement"
+      | "popperOptions"
+      | "matchTriggerWidth"
+    >,
+    Pick<React.ComponentProps<typeof Button>, "className" | "feel" | "style">,
+    Pick<
+      React.DetailedHTMLProps<
+        React.SelectHTMLAttributes<HTMLSelectElement>,
+        HTMLSelectElement
+      >,
+      "onChange" | "name" | "id"
+    > {
+  disabled?: boolean;
+  label?: React.ReactElement;
+
+  /**
+   * Callback called when the selected item changes
+   *
+   * This will be called syncronously after you try to close the menu. If you
+   * are running a long-running task, like fetching data or parseing something
+   * as the result of this handler; you might want to wrap your callback in a
+   * `setTimeout(... ,0)`.
+   */
+  onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
+
+  /**
+   * Item currently selected
+   *
+   * While I believe it's also valid to use the `<option>`'s `selected` prop; we
+   * are not using that here. We _might_ use that if we render a native `select`
+   * element in the future.
+   */
+  value?: NonNullable<OptionProps["value"]> | null;
+
+  /** Default value for a non-controlled component */
+  defaultValue?: NonNullable<OptionProps["value"]> | null;
+
+  size?: "auto" | "small" | "medium" | "extra large";
+}
+
+export const Select: React.FC<Props> = ({
+  children,
+  defaultValue,
+  disabled = false,
+  feel,
+  label,
+  matchTriggerWidth,
+  onChange,
+  placement = "bottom-start",
+  popperOptions,
+  size = "auto",
+  value: valueProp,
+  ...props
+}) => {
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(
+    defaultValue
+  );
+
+  // Validate controlled versus uncontrolled
+  if (
+    (typeof onChange !== "undefined" || typeof valueProp !== "undefined") &&
+    typeof defaultValue !== "undefined"
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Select component must be either controlled or uncontrolled. Pass either `defaultValue` for an uncontrolled component or `value` and optionally `onChange` for a controlled component."
+    );
+  }
+
+  const value =
+    typeof valueProp !== "undefined" ? valueProp : uncontrolledValue;
+
+  /**
+   * Reference to the underlying popper instance
+   *
+   * We'll use this to control the popover's visbility based on events captured
+   * by downshift
+   */
+  const instanceRef = React.useRef<
+    Parameters<NonNullable<React.ComponentProps<typeof Popover>["onCreate"]>>[0]
+  >();
+
+  const listConfig = useListConfig();
+
+  /**
+   * Items data represtented by the DOM structure in `children`
+   */
+  const items = reactNodeToDownshiftItems(children);
+
+  const {
+    getToggleButtonProps,
+    getMenuProps,
+    getItemProps,
+    selectedItem,
+    closeMenu,
+  } = useSelect<OptionProps>({
+    items,
+    scrollIntoView(node) {
+      // We have to defer this call until the popover has been created. I really
+      // don't have a great explanation for this; but this works and I can't see
+      // a downside because the extra complexity.
+      setTimeout(() => {
+        // It's silly to write code for our tests, but `scrollIntoView` doesn't
+        // exist in JSDOM, so we have to make sure we don't call it on tests or
+        // they'll break.
+        node.scrollIntoView?.({
+          behavior: "auto",
+          block: "nearest",
+          inline: "nearest",
+        });
+      }, 0);
+    },
+    selectedItem: items.find((item) => {
+      return item.value ? item.value === value : item.children === value;
+    }),
+    onSelectedItemChange: (event) => {
+      const newValue =
+        event.selectedItem?.value?.toString() ??
+        event.selectedItem?.children ??
+        "";
+
+      closeMenu();
+
+      if (onChange) {
+        // This is kind of hacky because there's no underlying `select` with
+        // native events firing. Maybe we should create them and then fire
+        // events?
+        onChange(({ target: { value: newValue } } as unknown) as ChangeEvent<
+          HTMLSelectElement
+        >);
+      } else {
+        setUncontrolledValue(newValue);
+      }
+    },
+    onIsOpenChange: (event) => {
+      if (event.isOpen) {
+        instanceRef.current?.show();
+      } else {
+        instanceRef.current?.hide();
+      }
+    },
+  });
+
+  return (
+    <ListConfigProvider {...listConfig} hoverColor={null}>
+      <ClassNames>
+        {({ css, cx }) => (
+          <Popover
+            popperOptions={popperOptions}
+            onCreate={(instance) => {
+              instanceRef.current = instance;
+            }}
+            content={
+              <List {...getMenuProps(undefined, { suppressRefError: true })}>
+                {React.Children.toArray(children)
+                  // Filter out falsy elements in `children`. We need to know if
+                  // we're rendering the first actual element in `children` to
+                  // know if we should add a divider or not. If the consumer uses
+                  // conditional logic in their rendering then we could have
+                  // `undefined` elements in `children`.
+                  .filter(
+                    (child): child is NonNullable<React.ReactNode> => !!child
+                  )
+                  .map((child, topLevelIndex) => {
+                    if (isHTMLOptionElement(child)) {
+                      return (
+                        <ListItemWrapper
+                          data-top-level-index={topLevelIndex}
+                          downshiftItems={items}
+                          element={child}
+                          getItemProps={getItemProps}
+                          key={
+                            child.props.value
+                              ? child.props.value.toString()
+                              : child.props.children
+                          }
+                        />
+                      );
+                    } else if (isHTMLOptgroupElement(child)) {
+                      return (
+                        <React.Fragment key={child.props.label}>
+                          {topLevelIndex > 0 && (
+                            <ListDivider data-top-level-index={topLevelIndex} />
+                          )}
+                          <ListHeading
+                            aria-label={child.props.label}
+                            role="group"
+                          >
+                            {child.props.label}
+                          </ListHeading>
+                          {React.Children.map(
+                            child.props.children as React.ReactElement<
+                              OptionProps,
+                              "option"
+                            >[],
+                            (optgroupChild) => {
+                              return (
+                                <ListItemWrapper
+                                  key={
+                                    optgroupChild.props.value
+                                      ? optgroupChild.props.value.toString()
+                                      : optgroupChild.props.children
+                                  }
+                                  downshiftItems={items}
+                                  element={optgroupChild}
+                                  getItemProps={getItemProps}
+                                />
+                              );
+                            }
+                          )}
+                        </React.Fragment>
+                      );
+                    }
+
+                    return null;
+                  })}
+              </List>
+            }
+            placement={placement}
+            triggerEvents="manual"
+            matchTriggerWidth={matchTriggerWidth}
+            trigger={
+              <Button
+                {...props}
+                {...getToggleButtonProps({ disabled })}
+                className={cx(
+                  css({
+                    textAlign: "left",
+                    maxWidth: {
+                      auto: undefined,
+                      small: 71,
+                      medium: 110,
+                      large: 157,
+                      "extra large": 188,
+                    }[size],
+                  }),
+                  props.className
+                )}
+                color={colors.white}
+                feel={feel}
+                type="button"
+                size={
+                  {
+                    auto: "small",
+                    small: "small",
+                    medium: "small",
+                    large: "small",
+                    "extra large": "default",
+                  }[size]
+                }
+                endIcon={
+                  <IconArrowDown
+                    className={css({ height: "70%" })}
+                    weight="thin"
+                  />
+                }
+              >
+                {selectedItem?.children || label}
+              </Button>
+            }
+          />
+        )}
+      </ClassNames>
+    </ListConfigProvider>
+  );
+};

--- a/src/Select/select/reactNodeToDownshiftItems.spec.tsx
+++ b/src/Select/select/reactNodeToDownshiftItems.spec.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { reactNodeToDownshiftItems } from "./reactNodeToDownshiftItems";
+
+it("should work with options with no `value` props", () => {
+  expect(
+    reactNodeToDownshiftItems([
+      <option key="a">a</option>,
+      <option key="b">b</option>,
+    ])
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+      },
+      Object {
+        "children": "b",
+      },
+    ]
+  `);
+});
+
+it("should work with options with `value` props", () => {
+  expect(
+    reactNodeToDownshiftItems([
+      <option key="a" value="value a">
+        a
+      </option>,
+      <option key="b" value="value b">
+        b
+      </option>,
+    ])
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+        "value": "value a",
+      },
+      Object {
+        "children": "b",
+        "value": "value b",
+      },
+    ]
+  `);
+});
+
+it("should work with options with forwarded refs", () => {
+  const Option = React.forwardRef<
+    HTMLOptionElement,
+    React.PropsWithChildren<
+      React.DetailedHTMLProps<
+        React.OptionHTMLAttributes<HTMLOptionElement>,
+        HTMLOptionElement
+      >
+    >
+  >((props, ref) => <option {...props} ref={ref} />);
+
+  expect(
+    reactNodeToDownshiftItems([
+      <Option key="a" value="value a">
+        a
+      </Option>,
+      <Option key="b" value="value b">
+        b
+      </Option>,
+    ])
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+        "value": "value a",
+      },
+      Object {
+        "children": "b",
+        "value": "value b",
+      },
+    ]
+  `);
+});
+
+it("given `optgroup` and `option`s, should return correct result", () => {
+  expect(
+    reactNodeToDownshiftItems(
+      <optgroup key="a" label="label a">
+        <option key="a">a</option>
+        <option key="b">b</option>
+      </optgroup>
+    )
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+      },
+      Object {
+        "children": "b",
+      },
+    ]
+  `);
+
+  expect(
+    reactNodeToDownshiftItems(
+      <optgroup key="a" label="label a">
+        <option key="a" value="a">
+          a
+        </option>
+        <option key="b" value="b">
+          b
+        </option>
+      </optgroup>
+    )
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+        "value": "a",
+      },
+      Object {
+        "children": "b",
+        "value": "b",
+      },
+    ]
+  `);
+});
+
+it("given mixed `optgroup` and `option`s without `value` props, should return correct result", () => {
+  expect(
+    reactNodeToDownshiftItems([
+      <optgroup key="a" label="label a">
+        <option key="a">a</option>
+        <option key="b">b</option>
+      </optgroup>,
+      <option key="c">c</option>,
+    ])
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+      },
+      Object {
+        "children": "b",
+      },
+      Object {
+        "children": "c",
+      },
+    ]
+  `);
+});
+
+it("given mixed `optgroup` and `option`s with `value` props, should return correct result", () => {
+  expect(
+    reactNodeToDownshiftItems([
+      <optgroup key="a" label="label a">
+        <option key="a" value="value a">
+          a
+        </option>
+        <option key="b" value="value b">
+          b
+        </option>
+      </optgroup>,
+      <option key="c" value="value c">
+        c
+      </option>,
+    ])
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "children": "a",
+        "value": "value a",
+      },
+      Object {
+        "children": "b",
+        "value": "value b",
+      },
+      Object {
+        "children": "c",
+        "value": "value c",
+      },
+    ]
+  `);
+});

--- a/src/Select/select/reactNodeToDownshiftItems.ts
+++ b/src/Select/select/reactNodeToDownshiftItems.ts
@@ -1,0 +1,91 @@
+import React from "react";
+import { render } from "react-dom";
+
+type OptionProps = Omit<
+  React.DetailedHTMLProps<
+    React.OptionHTMLAttributes<HTMLOptionElement>,
+    HTMLOptionElement
+  >,
+  "children"
+> & { children: string };
+
+type OptgroupProps = React.DetailedHTMLProps<
+  React.OptgroupHTMLAttributes<HTMLOptGroupElement>,
+  HTMLOptGroupElement
+>;
+
+export function isHTMLOptionElement(
+  element: React.ReactNode
+): element is React.ReactElement<OptionProps, "option"> {
+  if (!React.isValidElement(element)) {
+    return false;
+  }
+
+  // This is a special check performed only for MDX processing in storybook
+  if (element.props.originalType) {
+    return element.props.originalType === "option";
+  }
+
+  if (typeof element.type === "string") {
+    return element.type === "option";
+  }
+
+  return renderHTML(element) instanceof HTMLOptionElement;
+}
+
+function renderHTML(element: React.ReactElement) {
+  const div = document.createElement("div");
+  render(element, div);
+
+  if (div.childNodes.length !== 1) {
+    throw new Error("BUG: must only have one child");
+  }
+  return div.childNodes[0];
+}
+
+export function isHTMLOptgroupElement(
+  element: React.ReactNode
+): element is React.ReactElement<OptgroupProps, "optgroup"> {
+  if (!React.isValidElement(element)) {
+    return false;
+  }
+
+  // This is a special check performed only for MDX processing in storybook
+  if (element.props.originalType) {
+    return element.props.originalType === "optgroup";
+  }
+
+  if (typeof element.type === "string") {
+    return element.type === "optgroup";
+  }
+
+  return renderHTML(element) instanceof HTMLOptGroupElement;
+}
+
+/**
+ * Convert a `children` prop rendered with `<optgroup><option /></optgroup>` and
+ * `<option />` elements into an array of the props of each of those `option`
+ * elements.
+ */
+export function reactNodeToDownshiftItems(
+  children: React.ReactNode
+): OptionProps[] {
+  return React.Children.toArray(children).reduce<OptionProps[]>(
+    (accumulator, child) => {
+      if (isHTMLOptionElement(child)) {
+        return accumulator.concat(child.props);
+      }
+
+      if (!React.isValidElement(child)) {
+        return accumulator;
+      }
+
+      return accumulator.concat(
+        React.Children.toArray(child.props.children)
+          .filter(isHTMLOptionElement)
+          .map((optgroupChild) => optgroupChild.props)
+      );
+    },
+    []
+  );
+}

--- a/src/TextField/TextField.stories.mdx
+++ b/src/TextField/TextField.stories.mdx
@@ -90,6 +90,17 @@ Anatomy of a complete form field. A label is required (or at the very least, it 
   </Story>
 </Canvas>
 
+## Icon
+
+<Canvas>
+  <Story name="icon">
+    <TextField
+      icon={<IconShip2 style={{ height: 16, width: 16 }} />}
+      label="Input Label"
+    />
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={TextField} />

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -7,6 +7,61 @@ import { IconWarningSolid } from "../icons/IconWarningSolid";
 import { IconInfoSolid } from "../icons/IconInfoSolid";
 import classnames from "classnames";
 
+interface FormControlProps {
+  as?: React.ReactElement | keyof JSX.IntrinsicElements;
+}
+
+/**
+ * Component that wraps the outside of a form element and all it's contents
+ */
+export const FormControl: React.FC<FormControlProps> = ({
+  as = "div",
+  children,
+}) => {
+  return React.isValidElement(as)
+    ? React.cloneElement(as, undefined, children)
+    : React.createElement(as, undefined, children);
+};
+
+interface InputLabelProps
+  extends React.DetailedHTMLProps<
+    React.LabelHTMLAttributes<HTMLLabelElement>,
+    HTMLLabelElement
+  > {
+  as?: React.ReactElement | keyof JSX.IntrinsicElements;
+}
+
+export const InputLabel = React.forwardRef<HTMLLabelElement, InputLabelProps>(
+  ({ as = "label", children, ...props }, ref) => {
+    return (
+      <ClassNames>
+        {({ css, cx }) => {
+          const element = React.isValidElement(as)
+            ? as
+            : React.createElement(as);
+
+          return React.cloneElement(
+            element,
+            {
+              ...props,
+              className: cx(
+                css({
+                  paddingBottom: 8,
+                  ...typography.base.base,
+                  fontWeight: 600,
+                }),
+                element.props.className
+              ),
+              ref,
+            },
+            children
+          );
+        }}
+      </ClassNames>
+    );
+  }
+);
+
 interface Props {
   /**
    * Passed through to the underlying `input`
@@ -182,58 +237,52 @@ export const TextField: React.FC<Props> = ({
       };
 
       return (
-        <div className={className}>
-          <label
-            className={cx(
-              css({
-                paddingBottom: 8,
-                ...typography.base.base,
-                fontWeight: 600,
-              })
-            )}
-          >
-            {label != null && <div css={{ marginBottom: 4 }}>{label}</div>}
-            {description != null && (
-              <div
-                css={{
-                  ...typography.base.base,
-                  color: colors.black.base,
-                }}
-              >
-                {description}
-              </div>
-            )}
-            <div
-              css={{
-                marginTop: 8,
-                position: "relative",
-              }}
-            >
-              {icon && (
+        <FormControl as={<div className={className} />}>
+          <InputLabel>
+            <React.Fragment>
+              {label != null && <div css={{ marginBottom: 4 }}>{label}</div>}
+              {description != null && (
                 <div
                   css={{
-                    position: "absolute",
-                    display: "inline-flex",
-                    left: 12,
-                    top: "50%",
-                    transform: "translateY(-50%)",
+                    ...typography.base.base,
+                    color: colors.black.base,
                   }}
                 >
-                  {icon}
+                  {description}
                 </div>
               )}
+              <div
+                css={{
+                  marginTop: 8,
+                  position: "relative",
+                }}
+              >
+                {icon && (
+                  <div
+                    css={{
+                      position: "absolute",
+                      display: "inline-flex",
+                      left: 12,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                    }}
+                  >
+                    {icon}
+                  </div>
+                )}
 
-              {React.isValidElement(inputAs)
-                ? React.cloneElement(inputAs, {
-                    ...inputProps,
-                    className: classnames(
-                      inputProps.className,
-                      inputAs.props.className
-                    ),
-                  })
-                : React.createElement(inputAs, inputProps)}
-            </div>
-          </label>
+                {React.isValidElement(inputAs)
+                  ? React.cloneElement(inputAs, {
+                      ...inputProps,
+                      className: classnames(
+                        inputProps.className,
+                        inputAs.props.className
+                      ),
+                    })
+                  : React.createElement(inputAs, inputProps)}
+              </div>
+            </React.Fragment>
+          </InputLabel>
           <div
             css={{
               marginTop: 8,
@@ -279,7 +328,7 @@ export const TextField: React.FC<Props> = ({
               </div>
             )}
           </div>
-        </div>
+        </FormControl>
       );
     }}
   </ClassNames>


### PR DESCRIPTION
Review commit by commit :-D Check out the deploy preview docs page for configuration and tests to see how it works. This should be a drop-in replacement for native `<select>` components. If we need to add more props or just allow _all_ `HTMLSelectElement` props, we can do that too.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.19.1-canary.243.5813.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@7.19.1-canary.243.5813.0
  # or 
  yarn add @apollo/space-kit@7.19.1-canary.243.5813.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
