### PR TITLE
Remove extra top margin for TextField error

### DIFF
--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -285,7 +285,6 @@ export const TextField: React.FC<Props> = ({
           </InputLabel>
           <div
             css={{
-              marginTop: 8,
               alignItems: "center",
               position: "relative",
             }}


### PR DESCRIPTION
The child of this div also defines the same top margin so this won't affect the spacing. 
The margin made it so the TextField would have a bottom margin when theres no error and no bottom margin if there was an error (or helper) 

I needed some things to bottom align, so I had to override https://github.com/mdg-private/studio-ui/pull/3309/files#diff-9749735bbcd698b22a14d33a71362ee7c8d94da4725bd333a5fad713218412e2R341

I'm marking this as a major version cause I'll have to go through all the TextFields to make sure they are still spaced correctly. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.21.1-canary.246.5970.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@7.21.1-canary.246.5970.0
  # or 
  yarn add @apollo/space-kit@7.21.1-canary.246.5970.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
