### PR TITLE
AR-1672, AR-1909 Add `tr` and column-level `th`/`td` customization to `Table`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,9 +18,7 @@ module.exports = {
   snapshotSerializers: ["jest-emotion"],
   globals: {
     "ts-jest": {
-      diagnostics: {
-        warnOnly: true,
-      },
+      diagnostics: false,
     },
   },
   transformIgnorePatterns: ["/node_modules/(?!@popperjs/core).+\\.js$"],

--- a/src/Table/Table.spec.tsx
+++ b/src/Table/Table.spec.tsx
@@ -128,6 +128,44 @@ test("when passed col for columns, should render them", () => {
   `);
 });
 
+it("when passed `column` values for `th`, they are rendered", () => {
+  render(
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            { name: "Mason", firstWord: "Apollo" },
+            { name: "Sadie", firstWord: "GraphQL" },
+          ]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+              thAs: <th className={css({ color: colors.red.light })} />,
+            },
+            {
+              id: "firstWord",
+              headerTitle: "First Word Spoken",
+              render: ({ firstWord }) => firstWord,
+              thAs: <th className={css({ color: colors.blue.light })} />,
+            },
+          ]}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(document.querySelector("thead > tr > th")).toHaveStyleRule(
+    "color",
+    colors.red.light
+  );
+  expect(
+    document.querySelector("thead > tr > th:nth-of-type(2)")
+  ).toHaveStyleRule("color", colors.blue.light);
+});
+
 it("when passed `column` values for `td`, they are rendered", () => {
   render(
     <ClassNames>

--- a/src/Table/Table.spec.tsx
+++ b/src/Table/Table.spec.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import { Table } from "./Table";
 import { ClassNames } from "@emotion/core";
 import { matchers } from "jest-emotion";
+import { colors } from "../colors";
 
 // Add the custom matchers provided by 'jest-emotion'
 expect.extend(matchers);
@@ -125,6 +126,45 @@ test("when passed col for columns, should render them", () => {
       />
     </colgroup>
   `);
+});
+
+it("when passed `column` values for `td`, they are rendered", () => {
+  render(
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            { name: "Mason", firstWord: "Apollo" },
+            { name: "Sadie", firstWord: "GraphQL" },
+          ]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+              as: <td className={css({ color: colors.red.light })} />,
+            },
+            {
+              id: "firstWord",
+              headerTitle: "First Word Spoken",
+              render: ({ firstWord }) => firstWord,
+              as: <td className={css({ color: colors.blue.light })} />,
+            },
+          ]}
+          trAs={<tr className="injected-class" />}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(document.querySelector("tbody > tr > td")).toHaveStyleRule(
+    "color",
+    colors.red.light
+  );
+  expect(
+    document.querySelector("tbody > tr > td:nth-of-type(2)")
+  ).toHaveStyleRule("color", colors.blue.light);
 });
 
 it("when passed `trAs` single value, `className`s are merged to head and body `tr`s", () => {

--- a/src/Table/Table.spec.tsx
+++ b/src/Table/Table.spec.tsx
@@ -1,7 +1,12 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Table } from "./Table";
+import { ClassNames } from "@emotion/core";
+import { matchers } from "jest-emotion";
+
+// Add the custom matchers provided by 'jest-emotion'
+expect.extend(matchers);
 
 test("when passed headers in `columns`, should render them, even with no data", () => {
   const { container, getByText } = render(
@@ -120,4 +125,290 @@ test("when passed col for columns, should render them", () => {
       />
     </colgroup>
   `);
+});
+
+it("when passed `trAs` single value, `className`s are merged to head and body `tr`s", () => {
+  // We first test that the `tr` elements don't have the style, then that they
+  // do. This ensures that we're actually changing something to be what we want.
+
+  const headTr = () =>
+    document.querySelector<HTMLTableRowElement>("thead > tr");
+  const bodyTrs = (): HTMLTableRowElement[] =>
+    Array.from(document.querySelectorAll<HTMLTableRowElement>("tbody > tr"));
+
+  render(
+    <Table
+      keyOn="name"
+      data={[{ name: "Mason" }, { name: "Sadie" }]}
+      columns={[
+        {
+          id: "name",
+          headerTitle: "Name",
+          render: ({ name }) => name,
+        },
+      ]}
+      trAs={<tr className="injected-class" />}
+    />
+  );
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveClass("injected-class");
+  expect(headTr()).not.toHaveStyleRule("color", "red");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).not.toHaveStyleRule("color", "red");
+    expect(tr).toHaveClass("injected-class");
+  });
+
+  // We must call `cleanup` between renders if we want to test style properties
+  // because emotion uses side-effects to add styles to the DOM.
+  cleanup();
+
+  render(
+    <ClassNames>
+      {({ css, cx }) => (
+        <Table
+          keyOn="name"
+          data={[{ name: "Mason" }, { name: "Sadie" }]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+            },
+          ]}
+          trAs={<tr className={cx(css({ color: "red" }), "injected-class")} />}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveStyleRule("color", "red");
+  expect(headTr()).toHaveClass("injected-class");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).toHaveStyleRule("color", "red");
+    expect(tr).toHaveClass("injected-class");
+  });
+});
+
+it("when passed `trAs` with a `head` with additional classes, `className`s are merged to head and not body `tr`s", () => {
+  // We first test that the `tr` elements don't have the style, then that they
+  // do. This ensures that we're actually changing something to be what we want.
+
+  const headTr = () =>
+    document.querySelector<HTMLTableRowElement>("thead > tr");
+  const bodyTrs = (): HTMLTableRowElement[] =>
+    Array.from(document.querySelectorAll<HTMLTableRowElement>("tbody > tr"));
+
+  render(
+    <Table
+      keyOn="name"
+      data={[{ name: "Mason" }, { name: "Sadie" }]}
+      columns={[
+        {
+          id: "name",
+          headerTitle: "Name",
+          render: ({ name }) => name,
+        },
+      ]}
+      trAs={{ head: <tr className="injected-class" /> }}
+    />
+  );
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveClass("injected-class");
+  expect(headTr()).not.toHaveStyleRule("color", "red");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).not.toHaveStyleRule("color", "red");
+    expect(tr).not.toHaveClass("injected-class");
+  });
+
+  // We must call `cleanup` between renders if we want to test style properties
+  // because emotion uses side-effects to add styles to the DOM.
+  cleanup();
+
+  render(
+    <ClassNames>
+      {({ css, cx }) => (
+        <Table
+          keyOn="name"
+          data={[{ name: "Mason" }, { name: "Sadie" }]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+            },
+          ]}
+          trAs={{
+            head: (
+              <tr className={cx(css({ color: "red" }), "injected-class")} />
+            ),
+          }}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveStyleRule("color", "red");
+  expect(headTr()).toHaveClass("injected-class");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).not.toHaveStyleRule("color", "red");
+    expect(tr).not.toHaveClass("injected-class");
+  });
+});
+
+it("when passed `trAs` with a `body` with additional classes, `className`s are merged to body and not head `tr`s", () => {
+  // We first test that the `tr` elements don't have the style, then that they
+  // do. This ensures that we're actually changing something to be what we want.
+
+  const headTr = () =>
+    document.querySelector<HTMLTableRowElement>("thead > tr");
+  const bodyTrs = (): HTMLTableRowElement[] =>
+    Array.from(document.querySelectorAll<HTMLTableRowElement>("tbody > tr"));
+
+  render(
+    <Table
+      keyOn="name"
+      data={[{ name: "Mason" }, { name: "Sadie" }]}
+      columns={[
+        {
+          id: "name",
+          headerTitle: "Name",
+          render: ({ name }) => name,
+        },
+      ]}
+      trAs={{ body: <tr className="injected-class" /> }}
+    />
+  );
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).not.toHaveClass("injected-class");
+  expect(headTr()).not.toHaveStyleRule("color", "red");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).toHaveClass("injected-class");
+    expect(tr).not.toHaveStyleRule("color", "red");
+  });
+
+  // We must call `cleanup` between renders if we want to test style properties
+  // because emotion uses side-effects to add styles to the DOM.
+  cleanup();
+
+  render(
+    <ClassNames>
+      {({ css, cx }) => (
+        <Table
+          keyOn="name"
+          data={[{ name: "Mason" }, { name: "Sadie" }]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+            },
+          ]}
+          trAs={{
+            body: (
+              <tr className={cx(css({ color: "red" }), "injected-class")} />
+            ),
+          }}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).not.toHaveStyleRule("color", "red");
+  expect(headTr()).not.toHaveClass("injected-class");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).toHaveClass("injected-class");
+    expect(tr).toHaveStyleRule("color", "red");
+  });
+});
+
+it("when passed `trAs` with a `body` and `head` with different additional classes, `className`s are merged", () => {
+  // We first test that the `tr` elements don't have the style, then that they
+  // do. This ensures that we're actually changing something to be what we want.
+
+  const headTr = () =>
+    document.querySelector<HTMLTableRowElement>("thead > tr");
+  const bodyTrs = (): HTMLTableRowElement[] =>
+    Array.from(document.querySelectorAll<HTMLTableRowElement>("tbody > tr"));
+
+  render(
+    <Table
+      keyOn="name"
+      data={[{ name: "Mason" }, { name: "Sadie" }]}
+      columns={[
+        {
+          id: "name",
+          headerTitle: "Name",
+          render: ({ name }) => name,
+        },
+      ]}
+      trAs={{
+        body: <tr className="body-injected-class" />,
+        head: <tr className="head-injected-class" />,
+      }}
+    />
+  );
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveClass("head-injected-class");
+  expect(headTr()).not.toHaveClass("body-injected-class");
+  expect(headTr()).not.toHaveStyleRule("color", "red");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).toHaveClass("body-injected-class");
+    expect(tr).not.toHaveClass("head-injected-class");
+    expect(tr).not.toHaveStyleRule("color", "red");
+  });
+
+  // We must call `cleanup` between renders if we want to test style properties
+  // because emotion uses side-effects to add styles to the DOM.
+  cleanup();
+
+  render(
+    <ClassNames>
+      {({ css, cx }) => (
+        <Table
+          keyOn="name"
+          data={[{ name: "Mason" }, { name: "Sadie" }]}
+          columns={[
+            {
+              id: "name",
+              headerTitle: "Name",
+              render: ({ name }) => name,
+            },
+          ]}
+          trAs={{
+            body: (
+              <tr
+                className={cx(css({ color: "red" }), "body-injected-class")}
+              />
+            ),
+            head: (
+              <tr
+                className={cx(css({ color: "blue" }), "head-injected-class")}
+              />
+            ),
+          }}
+        />
+      )}
+    </ClassNames>
+  );
+
+  expect(headTr()).toBeInTheDocument();
+  expect(headTr()).toHaveStyleRule("color", "blue");
+  expect(headTr()).not.toHaveClass("body-injected-class");
+  expect(headTr()).toHaveClass("head-injected-class");
+  expect(bodyTrs()).toHaveLength(2);
+  bodyTrs().forEach((tr) => {
+    expect(tr).toHaveClass("body-injected-class");
+    expect(tr).not.toHaveClass("head-injected-class");
+    expect(tr).toHaveStyleRule("color", "red");
+  });
 });

--- a/src/Table/Table.stories.mdx
+++ b/src/Table/Table.stories.mdx
@@ -1,5 +1,7 @@
-import { Table } from "./Table";
+import { ClassNames } from "@emotion/core";
+import { colors } from "../colors";
 import { Meta, Story, ArgsTable, Canvas } from "@storybook/addon-docs/blocks";
+import { Table } from "./Table";
 
 <Meta title="Components/Table" component={Table} />
 
@@ -151,6 +153,115 @@ Table density is an important characteristic when considering how to present inf
         },
       ]}
     />
+  </Story>
+</Canvas>
+
+## `tr` customization
+
+You can customize how `tr`s are rendered by using the `trAs` prop. It accepts a single value (check the TypeScript types for what those values are, the props table will be a little obtuse). You can also pass an object with `head` and/or `body` (both are optional and default to "tr") keys to customize `thead > tr` and `tbody > tr` separately.
+
+### Customizing Both At Once
+
+<Canvas>
+  <Story name="single `trAs`">
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            {
+              name: "Alice Howell",
+              image: require("./table.stories/alice-howell.png"),
+            },
+            {
+              name: "Benjamin Lawrence",
+              image: require("./table.stories/benjamin-lawrence.png"),
+            },
+            {
+              name: "Cynthia Bowman",
+              image: require("./table.stories/cynthia-bowman.png"),
+            },
+            {
+              name: "Jeremy Jacobs",
+              image: require("./table.stories/jeremy-jacobs.png"),
+            },
+            {
+              name: "Jeremy Griffin",
+              image: require("./table.stories/jeremy-griffin.png"),
+            },
+          ]}
+          columns={[
+            {
+              id: "image",
+              render: ({ image }) => (
+                <img style={{ width: 24, height: 24 }} src={image} />
+              ),
+            },
+            {
+              id: "name",
+              headerTitle: "name",
+              render: ({ name }) => <>{name}</>,
+            },
+          ]}
+          trAs={<tr className={css({ color: colors.red.dark })} />}
+        />
+      )}
+    </ClassNames>
+  </Story>
+</Canvas>
+
+### Customizing separately
+
+Both the `head` and `body` keys in `trAs` are optional. They are both shown here to illustrate how it's used.
+
+<Canvas>
+  <Story name="separately configured `trAs`">
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            {
+              name: "Alice Howell",
+              image: require("./table.stories/alice-howell.png"),
+            },
+            {
+              name: "Benjamin Lawrence",
+              image: require("./table.stories/benjamin-lawrence.png"),
+            },
+            {
+              name: "Cynthia Bowman",
+              image: require("./table.stories/cynthia-bowman.png"),
+            },
+            {
+              name: "Jeremy Jacobs",
+              image: require("./table.stories/jeremy-jacobs.png"),
+            },
+            {
+              name: "Jeremy Griffin",
+              image: require("./table.stories/jeremy-griffin.png"),
+            },
+          ]}
+          columns={[
+            {
+              id: "image",
+              render: ({ image }) => (
+                <img style={{ width: 24, height: 24 }} src={image} />
+              ),
+            },
+            {
+              id: "name",
+              headerTitle: "name",
+              render: ({ name }) => <>{name}</>,
+            },
+          ]}
+          trAs={{
+            body: <tr className={css({ color: colors.red.dark })} />,
+            head: <tr className={css({ color: colors.orange.light })} />,
+          }}
+        />
+      )}
+    </ClassNames>
   </Story>
 </Canvas>
 

--- a/src/Table/Table.stories.mdx
+++ b/src/Table/Table.stories.mdx
@@ -156,6 +156,59 @@ Table density is an important characteristic when considering how to present inf
   </Story>
 </Canvas>
 
+## `td` customization
+
+You can customize how each column's `td` is rendered.
+
+<Canvas>
+  <Story name="column-level `td` as">
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            {
+              name: "Alice Howell",
+              image: require("./table.stories/alice-howell.png"),
+            },
+            {
+              name: "Benjamin Lawrence",
+              image: require("./table.stories/benjamin-lawrence.png"),
+            },
+            {
+              name: "Cynthia Bowman",
+              image: require("./table.stories/cynthia-bowman.png"),
+            },
+            {
+              name: "Jeremy Jacobs",
+              image: require("./table.stories/jeremy-jacobs.png"),
+            },
+            {
+              name: "Jeremy Griffin",
+              image: require("./table.stories/jeremy-griffin.png"),
+            },
+          ]}
+          columns={[
+            {
+              id: "image",
+              as: <td className={css({ width: 24 })} />,
+              render: ({ image }) => (
+                <img style={{ width: 24, height: 24 }} src={image} />
+              ),
+            },
+            {
+              id: "name",
+              headerTitle: "name",
+              as: <td className={css({ color: colors.red.dark })} />,
+              render: ({ name }) => <>{name}</>,
+            },
+          ]}
+        />
+      )}
+    </ClassNames>
+  </Story>
+</Canvas>
+
 ## `tr` customization
 
 You can customize how `tr`s are rendered by using the `trAs` prop. It accepts a single value (check the TypeScript types for what those values are, the props table will be a little obtuse). You can also pass an object with `head` and/or `body` (both are optional and default to "tr") keys to customize `thead > tr` and `tbody > tr` separately.

--- a/src/Table/Table.stories.mdx
+++ b/src/Table/Table.stories.mdx
@@ -209,6 +209,60 @@ You can customize how each column's `td` is rendered.
   </Story>
 </Canvas>
 
+## `th` customization
+
+You can customize how each column's `th` is rendered.
+
+<Canvas>
+  <Story name="column-level `th` as">
+    <ClassNames>
+      {({ css }) => (
+        <Table
+          keyOn="name"
+          data={[
+            {
+              name: "Alice Howell",
+              image: require("./table.stories/alice-howell.png"),
+            },
+            {
+              name: "Benjamin Lawrence",
+              image: require("./table.stories/benjamin-lawrence.png"),
+            },
+            {
+              name: "Cynthia Bowman",
+              image: require("./table.stories/cynthia-bowman.png"),
+            },
+            {
+              name: "Jeremy Jacobs",
+              image: require("./table.stories/jeremy-jacobs.png"),
+            },
+            {
+              name: "Jeremy Griffin",
+              image: require("./table.stories/jeremy-griffin.png"),
+            },
+          ]}
+          columns={[
+            {
+              id: "image",
+              headerTitle: "Icon",
+              thAs: <td className={css({ color: colors.blue.light })} />,
+              render: ({ image }) => (
+                <img style={{ width: 24, height: 24 }} src={image} />
+              ),
+            },
+            {
+              id: "name",
+              headerTitle: "name",
+              thAs: <td className={css({ color: colors.red.dark })} />,
+              render: ({ name }) => <>{name}</>,
+            },
+          ]}
+        />
+      )}
+    </ClassNames>
+  </Story>
+</Canvas>
+
 ## `tr` customization
 
 You can customize how `tr`s are rendered by using the `trAs` prop. It accepts a single value (check the TypeScript types for what those values are, the props table will be a little obtuse). You can also pass an object with `head` and/or `body` (both are optional and default to "tr") keys to customize `thead > tr` and `tbody > tr` separately.

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -94,6 +94,16 @@ interface Props<RowShape> {
       index: number,
       list: readonly RowShape[]
     ) => React.ReactNode;
+
+    /**
+     * Override the the default `th` element
+     *
+     * All props provided will be merged with props that this component adds,
+     * including `className`s being merged using emotion's `cx` function
+     *
+     * @default "th"
+     */
+    thAs?: As;
   }[];
 
   /**
@@ -188,19 +198,27 @@ export function Table<RowShape>({
                   headTrElement.props.className
                 ),
               },
-              ...columns.map(({ headerTitle, id }, colIndex) => (
-                <th
-                  key={id}
-                  className={css({
-                    fontWeight: 600,
-                    padding,
-                    paddingLeft: colIndex === 0 ? 0 : padding,
-                    paddingRight: colIndex === columns.length - 1 ? 0 : padding,
-                  })}
-                >
-                  {headerTitle}
-                </th>
-              ))
+              ...columns.map(({ headerTitle, id, thAs = "th" }, colIndex) => {
+                const element = createElementFromAs(thAs);
+
+                return React.cloneElement(
+                  element,
+                  {
+                    className: css(
+                      css({
+                        fontWeight: 600,
+                        padding,
+                        paddingLeft: colIndex === 0 ? 0 : padding,
+                        paddingRight:
+                          colIndex === columns.length - 1 ? 0 : padding,
+                      }),
+                      element.props.className
+                    ),
+                    key: id,
+                  },
+                  headerTitle
+                );
+              })
             )}
           </thead>
           <tbody>

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -37,6 +37,16 @@ interface Props<RowShape> {
    */
   columns: readonly {
     /**
+     * Override the the default element
+     *
+     * All props provided will be merged with props that this component adds,
+     * including `className`s being merged using emotion's `cx` function
+     *
+     * @default "td"
+     */
+    as?: As;
+
+    /**
      * Column's title
      */
     headerTitle?: React.ReactNode | string;
@@ -200,24 +210,31 @@ export function Table<RowShape>({
                 {
                   key: getRowKey(item),
                 },
-                ...columns.map(({ render, id }, colIndex) => (
-                  <td
-                    key={id}
-                    className={css({
-                      // no border on the bottom row
-                      borderBottom:
-                        index === data.length - 1
-                          ? `none`
-                          : `1px solid ${colors.silver.dark}`,
-                      padding,
-                      paddingLeft: colIndex === 0 ? 0 : padding,
-                      paddingRight:
-                        colIndex === columns.length - 1 ? 0 : padding,
-                    })}
-                  >
-                    {render(item, index, data)}
-                  </td>
-                ))
+                ...columns.map(({ as = "td", render, id }, colIndex) => {
+                  const element = createElementFromAs(as);
+
+                  return React.cloneElement(
+                    element,
+                    {
+                      key: id,
+                      className: cx(
+                        css({
+                          // no border on the bottom row
+                          borderBottom:
+                            index === data.length - 1
+                              ? `none`
+                              : `1px solid ${colors.silver.dark}`,
+                          padding,
+                          paddingLeft: colIndex === 0 ? 0 : padding,
+                          paddingRight:
+                            colIndex === columns.length - 1 ? 0 : padding,
+                        }),
+                        element.props.className
+                      ),
+                    },
+                    render(item, index, data)
+                  );
+                })
               )
             )}
           </tbody>

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,5 +1,4 @@
-/** @jsx jsx */
-import { jsx } from "@emotion/core";
+import { ClassNames } from "@emotion/core";
 import React from "react";
 import * as typography from "../typography";
 import { colors } from "../colors";
@@ -104,66 +103,71 @@ export function Table<RowShape>({
     typeof keyOn === "function" ? keyOn : (row: RowShape) => row[keyOn];
 
   return (
-    <table
-      css={{
-        borderCollapse: "collapse",
-        width: "100%",
-      }}
-    >
-      <colgroup>
-        {columns.map(({ colProps, id }) => (
-          <col key={id} {...colProps} />
-        ))}
-      </colgroup>
-
-      <thead>
-        <tr
-          css={{
-            borderBottom: `1px solid ${colors.silver.dark}`,
-          }}
+    <ClassNames>
+      {({ css }) => (
+        <table
+          className={css({
+            borderCollapse: "collapse",
+            width: "100%",
+          })}
         >
-          {columns.map(({ headerTitle, id }, colIndex) => (
-            <th
-              key={id}
-              css={{
-                ...typography.base.xsmall,
-                textTransform: "uppercase",
-                color: colors.grey.darker,
-                fontWeight: 600,
-                textAlign: "left",
-                padding,
-                paddingLeft: colIndex === 0 ? 0 : padding,
-                paddingRight: colIndex === columns.length - 1 ? 0 : padding,
-              }}
-            >
-              {headerTitle}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((item, index) => (
-          <tr key={getRowKey(item)}>
-            {columns.map(({ render, id }, colIndex) => (
-              <td
-                key={id}
-                css={{
-                  // no border on the bottom row
-                  borderBottom:
-                    index === data.length - 1
-                      ? `none`
-                      : `1px solid ${colors.silver.dark}`,
-                  padding,
-                  paddingLeft: colIndex === 0 ? 0 : padding,
-                  paddingRight: colIndex === columns.length - 1 ? 0 : padding,
-                }}
-              >
-                {render(item, index, data)}
-              </td>
+          <colgroup>
+            {columns.map(({ colProps, id }) => (
+              <col key={id} {...colProps} />
             ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+          </colgroup>
+
+          <thead>
+            <tr
+              className={css({
+                borderBottom: `1px solid ${colors.silver.dark}`,
+              })}
+            >
+              {columns.map(({ headerTitle, id }, colIndex) => (
+                <th
+                  key={id}
+                  className={css({
+                    ...typography.base.xsmall,
+                    textTransform: "uppercase",
+                    color: colors.grey.darker,
+                    fontWeight: 600,
+                    textAlign: "left",
+                    padding,
+                    paddingLeft: colIndex === 0 ? 0 : padding,
+                    paddingRight: colIndex === columns.length - 1 ? 0 : padding,
+                  })}
+                >
+                  {headerTitle}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((item, index) => (
+              <tr key={getRowKey(item)}>
+                {columns.map(({ render, id }, colIndex) => (
+                  <td
+                    key={id}
+                    className={css({
+                      // no border on the bottom row
+                      borderBottom:
+                        index === data.length - 1
+                          ? `none`
+                          : `1px solid ${colors.silver.dark}`,
+                      padding,
+                      paddingLeft: colIndex === 0 ? 0 : padding,
+                      paddingRight:
+                        colIndex === columns.length - 1 ? 0 : padding,
+                    })}
+                  >
+                    {render(item, index, data)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </ClassNames>
   );
 }


### PR DESCRIPTION
Add config for `tr`, `td`, and `th` in `Table`. Review commit-by-commit with whitespace turned off. I replaced the `css=` prop with the jsx pragma in `Table` with the `ClassNames` component to explicitly allow me to use `cx` to merge class names.

Resolves issues https://apollographql.atlassian.net/browse/AR-1672 and https://apollographql.atlassian.net/browse/AR-1909

## Release Notes

* Allow `tr`s in the `Table` component to be customized. You can pass a single `trAs` prop that accepts `keyof JSX.IntrinsicElements`, like `"tr"`, or a `React.ReactElement` that will be cloned with `React.cloneElement`. 

  This configuration accepts a single value that can be applied to both the `thead > tr` element and to `tbody > tr` elements. You can also configure them separately with `trAs={{ head: ..., body: ... }}`, of which both keys are optional (you can exclude either of them and the default of "tr" will be used). 

* Allow each `column`'s `td` and `th` to be customized

See the tests and storybook story docs for usage examples.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.18.1-canary.247.5724.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@7.18.1-canary.247.5724.0
  # or 
  yarn add @apollo/space-kit@7.18.1-canary.247.5724.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
