### PR TITLE
AR-1935 Reset `Button` css outline

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -363,6 +363,9 @@ export const Button = React.forwardRef<HTMLElement, Props>(
               className: cx(
                 css([
                   {
+                    "&:focus": {
+                      outline: 0,
+                    },
                     // We need to also set the `:hover` on `:disabled` so it has a
                     // higher specificity than any `:hover` classes passed in. This
                     // also means that both of these need to be overriden if we want


### PR DESCRIPTION
We recently changed the logic for displaying outlines on `Button`s from using `:focus` in css in conjunction with calling `blur()` after clicking on a button to remove the focus to using [`useFocusRing` from `react-aria`](https://react-spectrum.adobe.com/react-aria/useFocusRing.html). The new logic no longer does anything with `:focus { outline: ... }`. This causes any side-wide focus styles to now be applied to our buttons.

Remove the outline in css because we're controlling it internally now.

Resolves [AR-1935](https://apollographql.atlassian.net/browse/AP-1935)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.0.1-canary.255.6098.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.0.1-canary.255.6098.0
  # or 
  yarn add @apollo/space-kit@8.0.1-canary.255.6098.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
