### PR TITLE
Use Space Kit `Button` for `AlertCard` close button

### DIFF
--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -13,6 +13,7 @@ import { IconInfoSolid } from "../icons/IconInfoSolid";
 import { IconWarningSolid } from "../icons/IconWarningSolid";
 import { IconErrorSolid } from "../icons/IconErrorSolid";
 import { IconSuccessSolid } from "../icons/IconSuccessSolid";
+import { Button } from "../Button";
 
 interface AlertCardProps {
   /**
@@ -147,7 +148,6 @@ export const AlertCard: React.FC<AlertCardProps> = ({
             <div
               css={{
                 marginBottom: extended ? 14 : 6,
-                overflow: "hidden",
                 display: "flex",
               }}
             >
@@ -198,19 +198,40 @@ export const AlertCard: React.FC<AlertCardProps> = ({
                     : React.createElement(headingAs, headingProps);
                 }}
               </ClassNames>
-              <IconClose
+              <Button
                 onClick={onClose}
+                size="small"
+                feel="flat"
+                theme={theme}
                 css={{
+                  marginRight: -9,
+                  marginTop: -9,
                   color:
                     theme === "light"
                       ? colors.grey.lighter
-                      : theme === "dark"
-                      ? colors.midnight.lighter
-                      : assertUnreachable(theme),
-                  cursor: "pointer",
-                  width: 10,
-                  height: 10,
+                      : colors.midnight.lighter,
+                  ":hover": {
+                    backgroundColor: "transparent",
+                    color:
+                      theme === "light"
+                        ? colors.grey.light
+                        : colors.midnight.lightest,
+                  },
                 }}
+                color={
+                  {
+                    light: colors.grey.lighter,
+                    dark: colors.midnight.lighter,
+                  }[theme]
+                }
+                icon={
+                  <IconClose
+                    css={{
+                      width: 10,
+                      height: 10,
+                    }}
+                  />
+                }
               />
             </div>
 


### PR DESCRIPTION
This will increase the hit area and allow the x button to be tabbed to. We have a unique visual treatment for the x button so I just overrode the css with emotion.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.1-canary.272.6473.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.1.1-canary.272.6473.0
  # or 
  yarn add @apollo/space-kit@8.1.1-canary.272.6473.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
