### PR TITLE
fix(`Select`): include `currentTarget.value` in change event

### DIFF
--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -198,9 +198,10 @@ export const Select: React.FC<Props> = ({
         // This is kind of hacky because there's no underlying `select` with
         // native events firing. Maybe we should create them and then fire
         // events?
-        onChange(({ target: { value: newValue } } as unknown) as ChangeEvent<
-          HTMLSelectElement
-        >);
+        onChange(({
+          currentTarget: { value: newValue },
+          target: { value: newValue },
+        } as unknown) as ChangeEvent<HTMLSelectElement>);
       } else {
         setUncontrolledValue(newValue);
       }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.1-canary.273.6487.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.1.1-canary.273.6487.0
  # or 
  yarn add @apollo/space-kit@8.1.1-canary.273.6487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
