### PR TITLE
Button: Remove min-width

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -519,7 +519,7 @@ export const Button = React.forwardRef<HTMLElement, Props>(
                   {icon && (
                     <ButtonIcon
                       iconSize={iconSize}
-                      className={css({ margin: iconOnly ? 0 : "0 4px 0" })}
+                      className={css({ margin: iconOnly ? 0 : "0 8px 0 0" })}
                     >
                       {icon}
                     </ButtonIcon>

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -420,15 +420,7 @@ export const Button = React.forwardRef<HTMLElement, Props>(
                         : size === "large"
                         ? 42
                         : assertUnreachable(size)
-                      : endIcon
-                      ? 0
-                      : size === "small"
-                      ? 76
-                      : size === "default"
-                      ? 100
-                      : size === "large"
-                      ? 112
-                      : assertUnreachable(size),
+                      : 0,
 
                     // We have to set the Y padding because browsers (at least Chrome) has
                     // a non-symmetrical vertical padding applied by default.

--- a/src/Button/button.stories/ButtonLayout.tsx
+++ b/src/Button/button.stories/ButtonLayout.tsx
@@ -13,6 +13,7 @@ export const ButtonLayout: React.FC<Props> = ({ children, theme }) => (
       <div
         className={cx(
           css({
+            alignItems: "center",
             backgroundColor:
               theme === "light" ? colors.white : colors.black.base,
             border: "solid 1px #dee2e7",


### PR DESCRIPTION
@jglovier ; maybe we need buttons with longer names than "Rest"? These just look funny.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.1-canary.274.6538.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.2.1-canary.274.6538.0
  # or 
  yarn add @apollo/space-kit@8.2.1-canary.274.6538.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
