### PR TITLE
Add test for dynamically resizing content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18733,12 +18733,12 @@
       "dependencies": {
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -18746,7 +18746,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -18754,7 +18754,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -18762,7 +18762,7 @@
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -18771,7 +18771,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "requires": {
             "minipass": "^2.2.1"
@@ -18779,12 +18779,12 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -18793,7 +18793,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -18801,7 +18801,7 @@
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "requires": {
             "chownr": "^1.1.1",
@@ -18815,7 +18815,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }

--- a/src/Popover/PopoverTests.story.tsx
+++ b/src/Popover/PopoverTests.story.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { Button } from "../Button";
 import { findByRole } from "@testing-library/dom";
@@ -9,6 +9,45 @@ import { ListItem } from "../ListItem";
 import { PerformUserInteraction } from "../shared/PerformUserInteraction";
 import { storiesOf } from "@storybook/react";
 import { colors } from "../colors";
+import { IconArrowDown } from "../icons/IconArrowDown";
+
+function ResizablePopover() {
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <Popover
+      interactive
+      popperOptions={{ strategy: "fixed" }}
+      placement="bottom-start"
+      fallbackPlacements={["top-start"]}
+      maxWidth={280}
+      content={
+        <React.Fragment>
+          <Button
+            feel="flat"
+            onClick={() => setExpanded(!expanded)}
+            endIcon={<IconArrowDown weight="thin" style={{ height: 12 }} />}
+          >
+            Shapes
+          </Button>
+
+          {expanded && (
+            <ul>
+              <li>Circle</li>
+              <li>Rectangle</li>
+              <li>Square</li>
+              <li>Triangle</li>
+            </ul>
+          )}
+        </React.Fragment>
+      }
+      trigger={
+        <Button style={{ position: "absolute", left: 0, top: 0 }}>
+          Open Popover
+        </Button>
+      }
+    />
+  );
+}
 
 storiesOf("Tests/Popover", module)
   .addParameters({ component: Popover })
@@ -200,6 +239,26 @@ storiesOf("Tests/Popover", module)
             </Button>
           }
         />
+      </PerformUserInteraction>
+    </div>
+  ))
+  .add("when resizing content, popover resizes", () => (
+    <div
+      className="sk-scroll-container"
+      style={{
+        height: 300,
+        width: 300,
+        border: `1px solid ${colors.blue.base}`,
+        overflow: "hidden",
+        position: "relative",
+      }}
+    >
+      <PerformUserInteraction
+        callback={async () => {
+          userEvent.click(await findByRole(document.body, "button"));
+        }}
+      >
+        <ResizablePopover />
       </PerformUserInteraction>
     </div>
   ));

--- a/src/Popover/index.tsx
+++ b/src/Popover/index.tsx
@@ -107,6 +107,14 @@ export const Popover: React.FC<Props> = ({
                 state.modifiersData[name].boxElement = element;
               },
             },
+            {
+              name: "log",
+              enabled: true,
+              phase: "beforeMain",
+              fn({ state }) {
+                console.log(state.rects.popper);
+              },
+            },
             sizeModifier,
             {
               name: "maxSize",


### PR DESCRIPTION
@justinanastos this seems like a popper / tippy issue and I'm seeing a related problem with [the new filters](https://graph-manage-pr-3455.herokuapp.com/graph/engine/operations?schemaTag=prod) that use the `Popover` with dynamically sized content.  I noticed [this issue](https://github.com/popperjs/react-popper/issues/60) on `react-popper` that might have some clues (more for reference since we're only using `popper-core`).  Possibly we need to observe resizes and call `update`?

Another clue may be that when using `strategy: absolute` this fixes the reproduction (however it doesn't seem to fix the in-app filters).  

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.1-canary.277.6590.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.3.1-canary.277.6590.0
  # or 
  yarn add @apollo/space-kit@8.3.1-canary.277.6590.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
