### PR TITLE
Add opensource icon

### DIFF
--- a/src/icons/svgs/essentials/icon-opensource.svg
+++ b/src/icons/svgs/essentials/icon-opensource.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="26px" height="26px" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+    <title>Group 7 Copy 3</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Server" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Apollo-Federation-v3-Copy" transform="translate(-149.000000, -195.000000)">
+            <g id="Group-7" transform="translate(150.000000, 196.000000)">
+                <g id="Group-7-Copy-3">
+                    <g id="Group-7-Copy-2">
+                        <g id="Group-6">
+                            <g id="Group-3">
+                                <g id="Group-4-Copy-7">
+                                    <circle id="Oval" cx="12" cy="12" r="12"></circle>
+                                    <path d="M12,0 C18.627417,0 24,5.37215154 24,11.9990363 C24,17.0508188 20.8778513,21.373443 16.4577249,23.1428843 L13.7839636,16.4562257 C15.5515519,15.7482293 16.8,14.0194165 16.8,11.9990363 C16.8,9.34828241 14.6509668,7.19942179 12,7.19942179 C9.3490332,7.19942179 7.2,9.34828241 7.2,11.9990363 C7.2,14.0197955 8.44891659,15.748878 10.2170313,16.456624 L10.2170313,16.456624 L7.54327746,23.1432855 C3.12262072,21.3740964 0,17.0512007 0,11.9990363 C0,5.37215154 5.372583,0 12,0 Z" id="Combined-Shape" stroke="#000000" stroke-width="1.5"></path>
+                                </g>
+                                <path d="M12,20.4 C16.6391919,20.4 20.4,16.6391919 20.4,12 C20.4,7.3608081 16.6391919,3.6 12,3.6 C7.3608081,3.6 3.6,7.3608081 3.6,12" id="Oval-Copy-7" stroke="#000000" stroke-width="1.5" stroke-linecap="round" transform="translate(12.000000, 12.000000) rotate(-45.000000) translate(-12.000000, -12.000000) "></path>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This PR adds a new Open Source icon.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.2-canary.280.6763.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.3.2-canary.280.6763.0
  # or 
  yarn add @apollo/space-kit@8.3.2-canary.280.6763.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
