### PR TITLE
Fix controlled/uncontrolled switch

### DIFF
--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -252,7 +252,7 @@ export const Select: React.FC<Props> = ({
     },
     selectedItem: items.find((item) => {
       return value === (item.value ?? item.children);
-    }),
+    }) ?? null,
     onSelectedItemChange: (event) => {
       const newValue =
         event.selectedItem?.value?.toString() ??

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -250,9 +250,10 @@ export const Select: React.FC<Props> = ({
         });
       }, 0);
     },
-    selectedItem: items.find((item) => {
-      return value === (item.value ?? item.children);
-    }) ?? null,
+    selectedItem:
+      items.find((item) => {
+        return value === (item.value ?? item.children);
+      }) ?? null,
     onSelectedItemChange: (event) => {
       const newValue =
         event.selectedItem?.value?.toString() ??


### PR DESCRIPTION
Passing undefined to useSelect marks it as an uncontrolled component, which is never what we want here. Guard against cases (loading etc) where the value may not match the options list
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.5.1-canary.281.6897.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.5.1-canary.281.6897.0
  # or 
  yarn add @apollo/space-kit@8.5.1-canary.281.6897.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
