### PR TITLE
Tweak `Select` and sync input heights

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -11,6 +11,7 @@ import { useFocusRing } from "@react-aria/focus";
 import { mergeProps } from "@react-aria/utils";
 import omit from "lodash/omit";
 import { ButtonIcon } from "./button/ButtonIcon";
+import { inputHeightDictionary } from "../shared/inputHeightDictionary";
 
 type TLength = string | 0 | number;
 
@@ -90,6 +91,7 @@ function getHeight({
     case "small":
       return 28;
     case "default":
+    case "standard":
       return 36;
     case "large":
       return 42;
@@ -212,9 +214,12 @@ interface Props
   /**
    * Size of the button
    *
-   * @default "default"
+   * The `default` option has been deprecated but will probably never be removed
+   * for reverse compatability.
+   *
+   * @default "standard"
    */
-  size?: "default" | "small" | "large";
+  size?: keyof typeof inputHeightDictionary | "default";
 
   /**
    * Theme to display the button
@@ -273,12 +278,15 @@ export const Button = React.forwardRef<HTMLElement, Props>(
       feel = "raised",
       icon: iconProp,
       loading,
-      size = "default",
+      size = "standard",
       theme = "light",
       ...passthroughProps
     },
     ref,
   ) => {
+    if (size === "default") {
+      size = "standard";
+    }
     const { isFocusVisible, focusProps } = useFocusRing();
 
     const mergedProps = mergeProps(passthroughProps, as.props, focusProps, {
@@ -413,18 +421,14 @@ export const Button = React.forwardRef<HTMLElement, Props>(
                     height: getHeight({ size }),
 
                     minWidth: iconOnly
-                      ? size === "small"
-                        ? 28
-                        : size === "default"
-                        ? 36
-                        : size === "large"
-                        ? 42
-                        : assertUnreachable(size)
+                      ? inputHeightDictionary[
+                          size === "default" ? "standard" : size
+                        ]
                       : endIcon
                       ? 0
                       : size === "small"
                       ? 76
-                      : size === "default"
+                      : size === "default" || size === "standard"
                       ? 100
                       : size === "large"
                       ? 112

--- a/src/Select/Select.spec.tsx
+++ b/src/Select/Select.spec.tsx
@@ -10,7 +10,7 @@ import * as Yup from "yup";
 test('given no `value`, should render `<option value="" />`', () => {
   render(
     <SpaceKitProvider disableAnimations>
-      <Select initialValue="">
+      <Select defaultValue="">
         <option value="">select an item</option>
         <option value="a">a</option>
         <option value="b">b</option>
@@ -31,7 +31,7 @@ test("label props should be called back", () => {
     return (
       <>
         <label {...labelProps}>{labelText}</label>
-        <Select initialValue="" labelPropsCallbackRef={setLabelProps}>
+        <Select defaultValue="" labelPropsCallbackRef={setLabelProps}>
           <option value="">select an item</option>
           <option value="a">a</option>
           <option value="b">b</option>

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -165,7 +165,9 @@ By default, the component will match the width of it's content. The dropdown lis
 
 #### Sizes
 
-Selects will grow and shrink with the content to up until a point (TBD)
+Sizes conform to the same sizes across space kit.
+
+Selects will grow to fit their current content. You can use `style` or `className` to force the size. Contents will automatically truncate.
 
 <Canvas>
   <Story name="Small, Not Truncated">
@@ -174,18 +176,22 @@ Selects will grow and shrink with the content to up until a point (TBD)
     </Select>
   </Story>
   <Story name="Small, Truncated">
-    <Select size="small" defaultValue="small truncated">
+    <Select size="small" defaultValue="small truncated" style={{ width: 100 }}>
       <option>small truncated</option>
     </Select>
   </Story>
-  <Story name="Medium, Not Truncated">
-    <Select size="medium" defaultValue="medium">
-      <option>medium</option>
+  <Story name="Standard, Not Truncated">
+    <Select size="standard" defaultValue="standard">
+      <option>standard</option>
     </Select>
   </Story>
-  <Story name="Medium, Truncated">
-    <Select size="medium" defaultValue="medium truncated truncated">
-      <option>medium truncated truncated</option>
+  <Story name="Standard, Truncated">
+    <Select
+      size="standard"
+      defaultValue="standard truncated truncated"
+      style={{ width: 150 }}
+    >
+      <option>standard truncated truncated</option>
     </Select>
   </Story>
   <Story name="Large, Not Truncated">
@@ -194,18 +200,12 @@ Selects will grow and shrink with the content to up until a point (TBD)
     </Select>
   </Story>
   <Story name="Large, Truncated">
-    <Select size="large" defaultValue="large truncated truncated">
+    <Select
+      size="large"
+      defaultValue="large truncated truncated"
+      style={{ width: 200 }}
+    >
       <option>large truncated truncated</option>
-    </Select>
-  </Story>
-  <Story name="Extra Large, Not Truncated">
-    <Select size="extra large" defaultValue="extra large">
-      <option>extra large</option>
-    </Select>
-  </Story>
-  <Story name="Extra Large, Truncated">
-    <Select size="extra large" defaultValue="extra large truncated truncated">
-      <option>extra large truncated truncated</option>
     </Select>
   </Story>
 </Canvas>

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -48,7 +48,7 @@ You must use the same `<option>` and `<optgroup>` elements you would use for a n
 
 <Canvas>
   <Story name="basic options">
-    <Select aria-labelledby="basic-options-label" initialValue="">
+    <Select aria-labelledby="basic-options-label" defaultValue="">
       <option value="">Select an option</option>
       <option value="value a">a</option>
       <option value="value b">b</option>
@@ -101,7 +101,7 @@ If you inspect the `label` shown in the following story; you'll see that `id` an
 
 <Canvas>
   <Story name="basic options with label">
-    <SelectWithLabel label={<label>label</label>} initialValue="">
+    <SelectWithLabel label={<label>label</label>} defaultValue="">
       <option value="">Select an option</option>
       <option value="value a">a</option>
       <option value="value b">b</option>
@@ -115,7 +115,7 @@ If you inspect the `label` shown in the following story; you'll see that `id` an
 
 For controlled components, you must pass a `value` prop and have the option to pass an `onChange` prop. If you don't use an `onChange` prop, as expected, the `value` can not be changed.
 
-If you elect to use an uncontrolled component, do not pass `value` or `onChange` props. You can pass a `initialValue` for the initial to be set and then the component will control the state on it's own.
+If you elect to use an uncontrolled component, do not pass `value` or `onChange` props. You can pass a `defaultValue` for the initial to be set and then the component will control the state on it's own.
 
 ## Options
 
@@ -125,7 +125,7 @@ Selects can be displayed using any of the `feel` values from `Button`.
 
 <Canvas>
   <Story name="feel raised">
-    <Select feel="raised" initialValue="">
+    <Select feel="raised" defaultValue="">
       <option value="">select an item</option>
       <option>a</option>
       <optgroup label="header 1">
@@ -134,7 +134,7 @@ Selects can be displayed using any of the `feel` values from `Button`.
     </Select>
   </Story>
   <Story name="feel flat">
-    <Select feel="flat" initialValue="">
+    <Select feel="flat" defaultValue="">
       <option value="">select an item</option>
       <option>a</option>
       <optgroup label="header 1">
@@ -152,12 +152,12 @@ By default, the component will match the width of it's content. The dropdown lis
 
 <Canvas>
   <Story name="Automatic Size, Narrow">
-    <Select initialValue="a">
+    <Select defaultValue="a">
       <option>a</option>
     </Select>
   </Story>
   <Story name="Automatic Size, Wide">
-    <Select initialValue="this is a super long to show how wide the select will be">
+    <Select defaultValue="this is a super long to show how wide the select will be">
       <option>this is a super long to show how wide the select will be</option>
     </Select>
   </Story>
@@ -169,42 +169,42 @@ Selects will grow and shrink with the content to up until a point (TBD)
 
 <Canvas>
   <Story name="Small, Not Truncated">
-    <Select size="small" initialValue="small">
+    <Select size="small" defaultValue="small">
       <option>small</option>
     </Select>
   </Story>
   <Story name="Small, Truncated">
-    <Select size="small" initialValue="small truncated">
+    <Select size="small" defaultValue="small truncated">
       <option>small truncated</option>
     </Select>
   </Story>
   <Story name="Medium, Not Truncated">
-    <Select size="medium" initialValue="medium">
+    <Select size="medium" defaultValue="medium">
       <option>medium</option>
     </Select>
   </Story>
   <Story name="Medium, Truncated">
-    <Select size="medium" initialValue="medium truncated truncated">
+    <Select size="medium" defaultValue="medium truncated truncated">
       <option>medium truncated truncated</option>
     </Select>
   </Story>
   <Story name="Large, Not Truncated">
-    <Select size="large" initialValue="large">
+    <Select size="large" defaultValue="large">
       <option>large</option>
     </Select>
   </Story>
   <Story name="Large, Truncated">
-    <Select size="large" initialValue="large truncated truncated">
+    <Select size="large" defaultValue="large truncated truncated">
       <option>large truncated truncated</option>
     </Select>
   </Story>
   <Story name="Extra Large, Not Truncated">
-    <Select size="extra large" initialValue="extra large">
+    <Select size="extra large" defaultValue="extra large">
       <option>extra large</option>
     </Select>
   </Story>
   <Story name="Extra Large, Truncated">
-    <Select size="extra large" initialValue="extra large truncated truncated">
+    <Select size="extra large" defaultValue="extra large truncated truncated">
       <option>extra large truncated truncated</option>
     </Select>
   </Story>
@@ -216,7 +216,7 @@ The menu width can be fixed to match the trigger button size with the `matchTrig
 
 <Canvas>
   <Story name="Match Trigger Prop">
-    <Select initialValue="small" matchTriggerWidth style={{ width: 150 }}>
+    <Select defaultValue="small" matchTriggerWidth style={{ width: 150 }}>
       <option>small</option>
       <option>medium</option>
       <option>large</option>

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -134,14 +134,14 @@ interface Props
   value?: NonNullable<OptionProps["value"]> | null;
 
   /** Initial value for a non-controlled component */
-  initialValue?: NonNullable<OptionProps["value"]> | null;
+  defaultValue?: NonNullable<OptionProps["value"]> | null;
 
   size?: "auto" | "small" | "medium" | "extra large";
 }
 
 export const Select: React.FC<Props> = ({
   children,
-  initialValue,
+  defaultValue,
   disabled = false,
   feel,
   labelPropsCallbackRef,
@@ -156,17 +156,17 @@ export const Select: React.FC<Props> = ({
   ...props
 }) => {
   const [uncontrolledValue, setUncontrolledValue] = React.useState(
-    initialValue ?? "",
+    defaultValue ?? "",
   );
 
   // Validate controlled versus uncontrolled
   if (
     (typeof onChange !== "undefined" || typeof valueProp !== "undefined") &&
-    typeof initialValue !== "undefined"
+    typeof defaultValue !== "undefined"
   ) {
     // eslint-disable-next-line no-console
     console.warn(
-      "Select component must be either controlled or uncontrolled. Pass either `initialValue` for an uncontrolled component or `value` and optionally `onChange` for a controlled component.",
+      "Select component must be either controlled or uncontrolled. Pass either `defaultValue` for an uncontrolled component or `value` and optionally `onChange` for a controlled component.",
     );
   }
 

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -17,6 +17,7 @@ import {
 import { ListConfigProvider, useListConfig } from "../ListConfig";
 import { As, createElementFromAs } from "../shared/createElementFromAs";
 import useDeepCompareEffect from "use-deep-compare-effect";
+import { inputHeightDictionary } from "../shared/inputHeightDictionary";
 
 export type OptionProps = Omit<
   React.DetailedHTMLProps<
@@ -86,6 +87,10 @@ interface Props
       "onBlur" | "onChange" | "name" | "id"
     > {
   /**
+   * class name to apply to the trigger component
+   */
+  className?: string;
+  /**
    * `RefCallback` for props that should be spread onto a `label` component
    * associated with this `Select`.
    *
@@ -136,11 +141,12 @@ interface Props
   /** Initial value for a non-controlled component */
   defaultValue?: NonNullable<OptionProps["value"]> | null;
 
-  size?: "auto" | "small" | "medium" | "extra large";
+  size?: keyof typeof inputHeightDictionary;
 }
 
 export const Select: React.FC<Props> = ({
   children,
+  className,
   defaultValue,
   disabled = false,
   feel,
@@ -150,7 +156,7 @@ export const Select: React.FC<Props> = ({
   onChange,
   placement = "bottom-start",
   popperOptions,
-  size = "auto",
+  size = "standard",
   triggerAs = <Button />,
   value: valueProp,
   ...props
@@ -375,14 +381,8 @@ export const Select: React.FC<Props> = ({
                 className: cx(
                   css({
                     textAlign: "left",
-                    maxWidth: {
-                      auto: undefined,
-                      small: 71,
-                      medium: 110,
-                      large: 157,
-                      "extra large": 188,
-                    }[size],
                   }),
+                  className,
                   React.isValidElement(triggerAs) &&
                     (triggerAs.props as any).className,
                 ),
@@ -398,13 +398,7 @@ export const Select: React.FC<Props> = ({
                   blur();
                 },
                 type: "button",
-                size: {
-                  auto: "small",
-                  small: "small",
-                  medium: "small",
-                  large: "small",
-                  "extra large": "default",
-                }[size],
+                size,
 
                 endIcon: (
                   <IconArrowDown

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -6,7 +6,7 @@ import { colors } from "../colors";
 import { IconWarningSolid } from "../icons/IconWarningSolid";
 import { IconInfoSolid } from "../icons/IconInfoSolid";
 import classnames from "classnames";
-
+import { inputHeightDictionary } from "../shared/inputHeightDictionary";
 interface FormControlProps {
   as?: React.ReactElement | keyof JSX.IntrinsicElements;
 }
@@ -133,7 +133,7 @@ interface Props {
    *
    * Defaults to `standard`
    */
-  size?: "small" | "standard" | "large";
+  size?: keyof typeof inputHeightDictionary;
 
   /**
    * Whether or not to show the circle i icon to the left of helper text
@@ -207,7 +207,7 @@ export const TextField: React.FC<Props> = ({
             },
             borderRadius: 4,
             flex: 1,
-            height: size === "standard" ? 36 : size === "small" ? 28 : 42,
+            height: inputHeightDictionary[size],
             ...(size === "small"
               ? typography.base.small
               : typography.base.base),

--- a/src/shared/inputHeightDictionary.ts
+++ b/src/shared/inputHeightDictionary.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents the height of form components given all available sizes
+ */
+export const inputHeightDictionary = {
+  small: 28,
+  standard: 36,
+  large: 42,
+};


### PR DESCRIPTION
## Release Notes

- Select: Replace `initialValue` with `defaultValue`
- Sync input heights for `Button`, `TextField`, and `Select`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.7.1-canary.290.7193.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.7.1-canary.290.7193.0
  # or 
  yarn add @apollo/space-kit@8.7.1-canary.290.7193.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
