### PR TITLE
Enhance `Select`

### DIFF
--- a/src/List/List.spec.tsx
+++ b/src/List/List.spec.tsx
@@ -14,7 +14,7 @@ const DebugListConfig: React.FC = () => {
         return React.cloneElement(
           React.isValidElement(value) ? value : <div />,
           { "data-testid": key, key },
-          <>{value}</>,
+          <>{String(value)}</>,
         );
       })}
     </>
@@ -38,11 +38,12 @@ test("given no configuration, defaults values should be present", () => {
   );
 });
 
-test("given nested lists with configurations in both, correct values should propegate", () => {
+test("given nested lists with configurations in both, correct values should propogate", () => {
   const newValues: ReturnType<typeof useListConfig> = {
     endIconAs: <span />,
     hoverColor: colors.red.base,
     iconSize: "large",
+    margin: "none",
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
@@ -53,6 +54,7 @@ test("given nested lists with configurations in both, correct values should prop
       hoverColor={colors.blue.base}
       iconSize="small"
       padding="normal"
+      margin="auto"
       selectedColor={colors.green.base}
     >
       <List {...newValues}>
@@ -68,6 +70,7 @@ test("given nested lists with configurations in both, correct values should prop
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
     newValues.hoverColor ?? "",
   );
+  expect(screen.getByTestId("margin")).toHaveTextContent(newValues.margin);
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
     newValues.selectedColor,
@@ -77,11 +80,12 @@ test("given nested lists with configurations in both, correct values should prop
   );
 });
 
-test("given nested lists with the top level having default configuration and the child configuring everything, correct values should propegate", () => {
+test("given nested lists with the top level having default configuration and the child configuring everything, correct values should propogate", () => {
   const newValues: ReturnType<typeof useListConfig> = {
     endIconAs: <span />,
     hoverColor: colors.red.base,
     iconSize: "large",
+    margin: "none",
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
@@ -102,6 +106,7 @@ test("given nested lists with the top level having default configuration and the
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
     newValues.hoverColor ?? "",
   );
+  expect(screen.getByTestId("margin")).toHaveTextContent(newValues.margin);
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
     newValues.selectedColor,
@@ -112,11 +117,12 @@ test("given nested lists with the top level having default configuration and the
   );
 });
 
-test("given nested lists with the top level having configuration and the child using defaults, correct values should propegate", () => {
+test("given nested lists with the top level having configuration and the child using defaults, correct values should propogate", () => {
   const newValues: ReturnType<typeof useListConfig> = {
     endIconAs: <span />,
     hoverColor: colors.red.base,
     iconSize: "large",
+    margin: "none",
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
@@ -137,6 +143,7 @@ test("given nested lists with the top level having configuration and the child u
   expect(screen.getByTestId("hoverColor")).toHaveTextContent(
     newValues.hoverColor ?? "",
   );
+  expect(screen.getByTestId("margin")).toHaveTextContent(newValues.margin);
   expect(screen.getByTestId("padding")).toHaveTextContent(newValues.padding);
   expect(screen.getByTestId("selectedColor")).toHaveTextContent(
     newValues.selectedColor,

--- a/src/List/List.spec.tsx
+++ b/src/List/List.spec.tsx
@@ -47,6 +47,7 @@ test("given nested lists with configurations in both, correct values should prop
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
+    truncate: true,
   };
 
   render(
@@ -56,6 +57,7 @@ test("given nested lists with configurations in both, correct values should prop
       padding="normal"
       margin="auto"
       selectedColor={colors.green.base}
+      truncate={false}
     >
       <List {...newValues}>
         <DebugListConfig />
@@ -78,6 +80,9 @@ test("given nested lists with configurations in both, correct values should prop
   expect(screen.getByTestId("startIconAs").tagName).toBe(
     ((newValues.startIconAs.type as unknown) as string).toUpperCase(),
   );
+  expect(screen.getByTestId("truncate")).toHaveTextContent(
+    String(newValues.truncate),
+  );
 });
 
 test("given nested lists with the top level having default configuration and the child configuring everything, correct values should propogate", () => {
@@ -89,6 +94,7 @@ test("given nested lists with the top level having default configuration and the
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
+    truncate: false,
   };
 
   render(
@@ -115,6 +121,9 @@ test("given nested lists with the top level having default configuration and the
   expect(screen.getByTestId("startIconAs").tagName).toBe(
     ((newValues.startIconAs.type as unknown) as string).toUpperCase(),
   );
+  expect(screen.getByTestId("truncate")).toHaveTextContent(
+    String(newValues.truncate),
+  );
 });
 
 test("given nested lists with the top level having configuration and the child using defaults, correct values should propogate", () => {
@@ -126,6 +135,7 @@ test("given nested lists with the top level having configuration and the child u
     padding: "relaxed",
     selectedColor: colors.green.dark,
     startIconAs: <span />,
+    truncate: false,
   };
 
   render(
@@ -151,5 +161,8 @@ test("given nested lists with the top level having configuration and the child u
 
   expect(screen.getByTestId("startIconAs").tagName).toBe(
     ((newValues.startIconAs.type as unknown) as string).toUpperCase(),
+  );
+  expect(screen.getByTestId("truncate")).toHaveTextContent(
+    String(newValues.truncate),
   );
 });

--- a/src/List/List.story.mdx
+++ b/src/List/List.story.mdx
@@ -298,12 +298,23 @@ information and provide a nice visual grouping.
 
 Items should be truncated properly. This provides an example to show how to add a custom `endIcon` as well.
 
+### `truncate={true}`
+
 <Canvas>
   <Story name="flexbox truncation">
     <List
-      endIconAs={<div style={{ color: colors.grey.light, width: "auto" }} />}
+      endIconAs={
+        <div
+          style={{
+            alignSelf: "baseline",
+            color: colors.grey.light,
+            width: "auto",
+          }}
+        />
+      }
       iconSize="small"
       style={{ maxWidth: 280 }}
+      truncate
     >
       <ListHeading startIcon={null}>mdg-private-graphs</ListHeading>
       <ListItem startIcon={null} endIcon={<>1.9k rpm</>}>
@@ -315,7 +326,55 @@ Items should be truncated properly. This provides an example to show how to add 
         selected
         endIconAs={<div style={{ color: colors.white, width: "auto" }} />}
       >
+        really long test name really long test name
+      </ListItem>
+      <ListItem
+        startIcon={
+          <IconCheck
+            style={{
+              color: colors.blue.base,
+              width: "100%",
+              height: "100%",
+            }}
+          />
+        }
+        endIcon={<>0 rpm</>}
+      >
+        engine-eu
+      </ListItem>
+    </List>
+  </Story>
+</Canvas>
+
+### `truncate={false}`
+
+<Canvas>
+  <Story name="flexbox, no truncation">
+    <List
+      endIconAs={
+        <div
+          style={{
+            alignSelf: "baseline",
+            color: colors.grey.light,
+            width: "auto",
+          }}
+        />
+      }
+      iconSize="small"
+      style={{ maxWidth: 280 }}
+      truncate={false}
+    >
+      <ListHeading startIcon={null}>mdg-private-graphs</ListHeading>
+      <ListItem startIcon={null} endIcon={<>1.9k rpm</>}>
         really_long_test_name_really_long_test_name
+      </ListItem>
+      <ListItem
+        startIcon={null}
+        endIcon={<>8 rpm</>}
+        selected
+        endIconAs={<div style={{ color: colors.white, width: "auto" }} />}
+      >
+        really long test name really long test name
       </ListItem>
       <ListItem
         startIcon={

--- a/src/List/List.story.mdx
+++ b/src/List/List.story.mdx
@@ -418,6 +418,33 @@ Padding is used to calculate the margin between elements and to add a negative m
   </Story>
 </Canvas>
 
+## `margin`
+
+Determines if the margin around liste items will be the default or removed completely
+
+<Canvas>
+  <Story name="Margin=auto">
+    <List margin="auto" style={{ border: "1px solid black" }}>
+      <ListItem selected>Root</ListItem>
+      <ListItem data-force-hover-state>Objects</ListItem>
+      <ListItem>Inputs</ListItem>
+      <ListItem>Interfaces</ListItem>
+      <ListItem>Unions</ListItem>
+      <ListItem>Scalars and Enums</ListItem>
+    </List>
+  </Story>
+  <Story name="Margin=none">
+    <List margin="none" style={{ border: "1px solid black" }}>
+      <ListItem selected>Root</ListItem>
+      <ListItem data-force-hover-state>Objects</ListItem>
+      <ListItem>Inputs</ListItem>
+      <ListItem>Interfaces</ListItem>
+      <ListItem>Unions</ListItem>
+      <ListItem>Scalars and Enums</ListItem>
+    </List>
+  </Story>
+</Canvas>
+
 ## `as`
 
 Specify the element used to render the button with the `as` prop. The default is `<div />`.

--- a/src/List/index.tsx
+++ b/src/List/index.tsx
@@ -41,13 +41,13 @@ export const List = React.forwardRef<
      */
     const listConfig: ReturnType<typeof useListConfig> = {
       ...useListConfig(),
-      ...(margin && { margin }),
-      ...(endIconAs && { endIconAs }),
-      ...(hoverColor && { hoverColor }),
-      ...(iconSize && { iconSize }),
-      ...(padding && { padding }),
-      ...(selectedColor && { selectedColor }),
-      ...(startIconAs && { startIconAs }),
+      ...(typeof endIconAs !== "undefined" && { endIconAs }),
+      ...(typeof hoverColor !== "undefined" && { hoverColor }),
+      ...(typeof iconSize !== "undefined" && { iconSize }),
+      ...(typeof margin !== "undefined" && { margin }),
+      ...(typeof padding !== "undefined" && { padding }),
+      ...(typeof selectedColor !== "undefined" && { selectedColor }),
+      ...(typeof startIconAs !== "undefined" && { startIconAs }),
     };
 
     const verticalMargin =

--- a/src/List/index.tsx
+++ b/src/List/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { css, jsx } from "@emotion/core";
 import { ListConfigProvider, useListConfig } from "../ListConfig";
 import { verticalListMarginFromPadding } from "../shared/verticalListMarginFromPadding";
+import { assertUnreachable } from "../shared/assertUnreachable";
 
 interface Props
   extends Omit<React.ComponentProps<typeof ListConfigProvider>, "children">,
@@ -26,6 +27,7 @@ export const List = React.forwardRef<
       endIconAs,
       hoverColor,
       iconSize,
+      margin,
       padding,
       selectedColor,
       startIconAs,
@@ -39,6 +41,7 @@ export const List = React.forwardRef<
      */
     const listConfig: ReturnType<typeof useListConfig> = {
       ...useListConfig(),
+      ...(margin && { margin }),
       ...(endIconAs && { endIconAs }),
       ...(hoverColor && { hoverColor }),
       ...(iconSize && { iconSize }),
@@ -48,7 +51,18 @@ export const List = React.forwardRef<
     };
 
     const verticalMargin =
-      -verticalListMarginFromPadding(listConfig.padding) / 2;
+      -verticalListMarginFromPadding(listConfig.padding) / 2 +
+      (listConfig.margin === "none"
+        ? -6
+        : listConfig.margin === "auto"
+        ? 0
+        : assertUnreachable(listConfig.margin));
+    const horizontalMargin =
+      listConfig.margin === "none"
+        ? -6
+        : listConfig.margin === "auto"
+        ? 0
+        : assertUnreachable(listConfig.margin);
 
     return (
       <ListConfigProvider {...listConfig}>
@@ -60,6 +74,8 @@ export const List = React.forwardRef<
           css={css({
             marginTop: verticalMargin,
             marginBottom: verticalMargin,
+            marginLeft: horizontalMargin,
+            marginRight: horizontalMargin,
             outline: "none",
           })}
         >

--- a/src/List/index.tsx
+++ b/src/List/index.tsx
@@ -31,6 +31,7 @@ export const List = React.forwardRef<
       padding,
       selectedColor,
       startIconAs,
+      truncate,
       ...props
     },
     ref,
@@ -48,6 +49,7 @@ export const List = React.forwardRef<
       ...(typeof padding !== "undefined" && { padding }),
       ...(typeof selectedColor !== "undefined" && { selectedColor }),
       ...(typeof startIconAs !== "undefined" && { startIconAs }),
+      ...(typeof truncate !== "undefined" && { truncate }),
     };
 
     const verticalMargin =

--- a/src/ListConfig/index.tsx
+++ b/src/ListConfig/index.tsx
@@ -34,6 +34,15 @@ interface ListConfig {
   iconSize: IconSize;
 
   /**
+   * The margin to place around list items between the edge of the `List` and
+   * other `ListItem`s. Using "none" will indicate that there is no margin for
+   * an edge-to-edge feel.
+   *
+   * @default "auto"
+   */
+  margin: "auto" | "none";
+
+  /**
    * Padding level on menu items
    */
   padding: "normal" | "relaxed";
@@ -63,6 +72,7 @@ export const defaults: ListConfig = {
   endIconAs: <div />,
   hoverColor: colors.silver.light,
   iconSize: "normal",
+  margin: "auto",
   padding: "normal",
   selectedColor: colors.blue.base,
   startIconAs: <div />,

--- a/src/ListConfig/index.tsx
+++ b/src/ListConfig/index.tsx
@@ -63,6 +63,15 @@ interface ListConfig {
    * @default <div />
    */
   startIconAs: React.ReactElement;
+
+  /**
+   * Indicates if text should be truncated when it will overflow the boundary.
+   * `true` incidates use an ellipsis and `false` indicates to allow line
+   * breaks.
+   *
+   * @default true
+   */
+  truncate: boolean;
 }
 
 /**
@@ -76,6 +85,7 @@ export const defaults: ListConfig = {
   padding: "normal",
   selectedColor: colors.blue.base,
   startIconAs: <div />,
+  truncate: true,
 };
 
 /**

--- a/src/ListItem/index.tsx
+++ b/src/ListItem/index.tsx
@@ -124,6 +124,7 @@ export const ListItem = React.forwardRef<
     const {
       hoverColor,
       iconSize,
+      margin,
       padding,
       selectedColor,
       ...listConfig
@@ -177,7 +178,12 @@ export const ListItem = React.forwardRef<
                     ...(highlighted && !selected && highlightedStyles),
                     alignItems: "center",
                     cursor: interactive ? "pointer" : undefined,
-                    borderRadius: 4,
+                    borderRadius:
+                      margin === "auto"
+                        ? 4
+                        : margin === "none"
+                        ? 0
+                        : assertUnreachable(margin),
                     display: "flex",
                     height:
                       padding === "normal"
@@ -185,8 +191,20 @@ export const ListItem = React.forwardRef<
                         : padding === "relaxed"
                         ? 40
                         : assertUnreachable(padding),
-                    paddingLeft: 12,
-                    paddingRight: 12,
+                    paddingLeft:
+                      12 +
+                      (margin === "none"
+                        ? 6
+                        : margin === "auto"
+                        ? 0
+                        : assertUnreachable(margin)),
+                    paddingRight:
+                      12 +
+                      (margin === "none"
+                        ? 6
+                        : margin === "auto"
+                        ? 0
+                        : assertUnreachable(margin)),
                     paddingTop: 4,
                     paddingBottom: 4,
                     marginTop: verticalMargin,

--- a/src/ListItem/index.tsx
+++ b/src/ListItem/index.tsx
@@ -127,6 +127,7 @@ export const ListItem = React.forwardRef<
       margin,
       padding,
       selectedColor,
+      truncate,
       ...listConfig
     } = useListConfig();
 
@@ -176,7 +177,7 @@ export const ListItem = React.forwardRef<
                       "&:hover, &[data-force-hover-state]": highlightedStyles,
                     }),
                     ...(highlighted && !selected && highlightedStyles),
-                    alignItems: "center",
+                    alignItems: "baseline",
                     cursor: interactive ? "pointer" : undefined,
                     borderRadius:
                       margin === "auto"
@@ -185,12 +186,13 @@ export const ListItem = React.forwardRef<
                         ? 0
                         : assertUnreachable(margin),
                     display: "flex",
-                    height:
-                      padding === "normal"
-                        ? 28
-                        : padding === "relaxed"
-                        ? 40
-                        : assertUnreachable(padding),
+                    height: !truncate
+                      ? "auto"
+                      : padding === "normal"
+                      ? 28
+                      : padding === "relaxed"
+                      ? 40
+                      : assertUnreachable(padding),
                     paddingLeft:
                       12 +
                       (margin === "none"
@@ -220,6 +222,7 @@ export const ListItem = React.forwardRef<
                   <div
                     className={cx(
                       css({
+                        alignSelf: "center",
                         display: "flex",
                         flex: "none",
                         marginLeft: getIconMarginLeft(iconSize),
@@ -241,8 +244,11 @@ export const ListItem = React.forwardRef<
                     minWidth: 0,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
                   }),
+                  truncate &&
+                    css({
+                      whiteSpace: "nowrap",
+                    }),
                 )}
               >
                 {children}
@@ -253,6 +259,7 @@ export const ListItem = React.forwardRef<
                   <div
                     className={cx(
                       css({
+                        alignSelf: "center",
                         display: "flex",
                         flex: "none",
                         justifyContent: "flex-end",

--- a/src/ListItem/index.tsx
+++ b/src/ListItem/index.tsx
@@ -7,7 +7,6 @@ import { colors } from "../colors";
 import { useListConfig } from "../ListConfig";
 import { verticalListMarginFromPadding } from "../shared/verticalListMarginFromPadding";
 import { cloneElements } from "../shared/cloneElements";
-import classnames from "classnames";
 
 function getIconHorizontalPadding(
   iconSize: NonNullable<ReturnType<typeof useListConfig>["iconSize"]>,
@@ -167,52 +166,51 @@ export const ListItem = React.forwardRef<
             as,
             <div
               {...props}
-              className={classnames(
-                props.className,
-                cx(
-                  css({
-                    ...(selected && selectedStyles),
-                    ...{ "&[aria-expanded=true]": selectedStyles },
-                    ...(!selected && {
-                      "&:hover, &[data-force-hover-state]": highlightedStyles,
-                    }),
-                    ...(highlighted && !selected && highlightedStyles),
-                    alignItems: "baseline",
-                    cursor: interactive ? "pointer" : undefined,
-                    borderRadius:
-                      margin === "auto"
-                        ? 4
-                        : margin === "none"
-                        ? 0
-                        : assertUnreachable(margin),
-                    display: "flex",
-                    height: !truncate
-                      ? "auto"
-                      : padding === "normal"
-                      ? 28
-                      : padding === "relaxed"
-                      ? 40
-                      : assertUnreachable(padding),
-                    paddingLeft:
-                      12 +
-                      (margin === "none"
-                        ? 6
-                        : margin === "auto"
-                        ? 0
-                        : assertUnreachable(margin)),
-                    paddingRight:
-                      12 +
-                      (margin === "none"
-                        ? 6
-                        : margin === "auto"
-                        ? 0
-                        : assertUnreachable(margin)),
-                    paddingTop: 4,
-                    paddingBottom: 4,
-                    marginTop: verticalMargin,
-                    marginBottom: verticalMargin,
+              className={cx(
+                css({
+                  ...(selected && selectedStyles),
+                  ...{ "&[aria-expanded=true]": selectedStyles },
+                  ...(!selected && {
+                    "&:hover, &[data-force-hover-state]": highlightedStyles,
                   }),
-                ),
+                  ...(highlighted && !selected && highlightedStyles),
+                  alignItems: "center",
+                  cursor: interactive ? "pointer" : undefined,
+                  borderRadius:
+                    margin === "auto"
+                      ? 4
+                      : margin === "none"
+                      ? 0
+                      : assertUnreachable(margin),
+                  display: "flex",
+                  height: !truncate
+                    ? "auto"
+                    : padding === "normal"
+                    ? 28
+                    : padding === "relaxed"
+                    ? 40
+                    : assertUnreachable(padding),
+                  paddingLeft:
+                    12 +
+                    (margin === "none"
+                      ? 6
+                      : margin === "auto"
+                      ? 0
+                      : assertUnreachable(margin)),
+                  paddingRight:
+                    12 +
+                    (margin === "none"
+                      ? 6
+                      : margin === "auto"
+                      ? 0
+                      : assertUnreachable(margin)),
+                  paddingTop: 4,
+                  paddingBottom: 4,
+                  marginTop: verticalMargin,
+                  marginBottom: verticalMargin,
+                }),
+
+                props.className,
               )}
               ref={ref}
             >

--- a/src/Popover/Popover.story.mdx
+++ b/src/Popover/Popover.story.mdx
@@ -41,6 +41,30 @@ The simple list provides a list of options for a user to choose from and updates
       />
     </PerformUserInteraction>
   </Story>
+  <Story name="margin=none">
+    <PerformUserInteraction
+      callback={async () => {
+        userEvent.click(await findByRole(document.body, "button"));
+      }}
+    >
+      <Popover
+        popperOptions={{ strategy: "fixed" }}
+        placement="bottom-start"
+        style={{ padding: 0 }}
+        content={
+          <List margin="none">
+            <ListItem>Root</ListItem>
+            <ListItem selected>Objects</ListItem>
+            <ListItem>Inputs</ListItem>
+            <ListItem>Interfaces</ListItem>
+            <ListItem>Unions</ListItem>
+            <ListItem>Scalars and Enums</ListItem>
+          </List>
+        }
+        trigger={<Button>Open Popover</Button>}
+      />
+    </PerformUserInteraction>
+  </Story>
   <Story name="interactive">
     <PerformUserInteraction
       callback={async () => {

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -105,11 +105,12 @@ export const RichOption = ({ title, description }) => (
 <Canvas>
   <Story name="rich option children">
     <Select
-      defaultValue=""
+      defaultValue="Consumer"
       listFeel="borderless"
       renderTriggerNode={(selectedItem) => (
         <>{selectedItem?.value ?? "select an item"}</>
       )}
+      selectionIndicator="checkmark"
     >
       <option value="Consumer" style={{ height: "auto" }}>
         <RichOption
@@ -186,6 +187,21 @@ For controlled components, you must pass a `value` prop and have the option to p
 If you elect to use an uncontrolled component, do not pass `value` or `onChange` props. You can pass a `defaultValue` for the initial to be set and then the component will control the state on it's own.
 
 ## Options
+
+### `selectionIndicator`
+
+We have the option to use a custom decoration to indicate an item is selected. Note that this is different from when an item is highlighted from a hover or keyboard arrow.
+
+#### `checkmark`
+
+<Canvas>
+  <Story name="selectionIndicator, checkmark">
+    <Select feel="flat" defaultValue="a" selectionIndicator="checkmark">
+      <option>a</option>
+      <option>b</option>
+    </Select>
+  </Story>
+</Canvas>
 
 ### Feel
 

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -106,11 +106,12 @@ export const RichOption = ({ title, description }) => (
   <Story name="rich option children">
     <Select
       defaultValue="Consumer"
-      listFeel="borderless"
+      margin="none"
       renderTriggerNode={(selectedItem) => (
         <>{selectedItem?.value ?? "select an item"}</>
       )}
       selectionIndicator="checkmark"
+      truncate={false}
     >
       <option value="Consumer" style={{ height: "auto" }}>
         <RichOption

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -5,6 +5,7 @@ import { Meta, Story, ArgsTable, Canvas } from "@storybook/addon-docs/blocks";
 import { PerformUserInteraction } from "../shared/PerformUserInteraction";
 import { Select as SpaceKitSelect } from "../Select";
 import userEvent from "@testing-library/user-event";
+import { base } from "../../typography";
 
 <Meta title="Form/Select" component={SpaceKitSelect} />
 
@@ -86,6 +87,54 @@ You must use the same `<option>` and `<optgroup>` elements you would use for a n
     >
       <option value="value a">a</option>
       <option value="value b">b</option>
+    </Select>
+  </Story>
+</Canvas>
+
+## Custom content
+
+You can provide whatever you want as `children` to the `option` elements. The selection rendering requires that we are either given or can infer a value of each option element. You can pass a `value` prop or pass a `string`, `number`, or `null` as the `children` prop. Anything else will result in a `TypeError` being thrown.
+
+export const RichOption = ({ title, description }) => (
+  <div style={{ whiteSpace: "normal", overflow: "auto" }}>
+    <div style={{ ...base.base, fontWeight: "semibold" }}>{title}</div>
+    <div style={{ opacity: 0.75 }}>{description}</div>
+  </div>
+);
+
+<Canvas>
+  <Story name="rich option children">
+    <Select
+      defaultValue=""
+      listFeel="borderless"
+      renderTriggerNode={(selectedItem) => (
+        <>{selectedItem?.value ?? "select an item"}</>
+      )}
+    >
+      <option value="Consumer" style={{ height: "auto" }}>
+        <RichOption
+          title="Consumer"
+          description="Limited read-only user. Can use the Explorer, Schema Reference, and Changelog, but cannot see any graph metrics."
+        />
+      </option>
+      <option value="Observer" style={{ height: "auto" }}>
+        <RichOption
+          title="Observer"
+          description="Read-only user. Can view schemas and metrics on all graphs in the organization."
+        />
+      </option>
+      <option value="Contributor" style={{ height: "auto" }}>
+        <RichOption
+          title="Contributor"
+          description="Can view all graph data and push new schema versions to graphs in the org, but cannot manage graph configurations."
+        />
+      </option>
+      <option value="Graph Admin" style={{ height: "auto" }}>
+        <RichOption
+          title="Graph Admin"
+          description="Can view and manage configuration for every graph in the organization, but cannot manage members and billing."
+        />
+      </option>
     </Select>
   </Story>
 </Canvas>

--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -72,7 +72,7 @@ You must use the same `<option>` and `<optgroup>` elements you would use for a n
         <option value="value a">a</option>
         <option value="value b">b</option>
       </optgroup>
-      <optgroup label="Second of options">
+      <optgroup>
         <option value="value c">c</option>
         <option value="value d">d</option>
       </optgroup>

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -423,12 +423,14 @@ export const Select: React.FC<Props> = ({
                         {topLevelIndex > 0 && (
                           <ListDivider data-top-level-index={topLevelIndex} />
                         )}
-                        <ListHeading
-                          aria-label={child.props.label}
-                          role="group"
-                        >
-                          {child.props.label}
-                        </ListHeading>
+                        {child.props.label && (
+                          <ListHeading
+                            aria-label={child.props.label}
+                            role="group"
+                          >
+                            {child.props.label}
+                          </ListHeading>
+                        )}
                         {React.Children.map(
                           child.props.children as React.ReactElement<
                             OptionProps,

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -19,14 +19,12 @@ import { As, createElementFromAs } from "../shared/createElementFromAs";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import { inputHeightDictionary } from "../shared/inputHeightDictionary";
 import { useFormControlContext } from "../FormControl";
+import { getEffectiveValueFromOptionElementProps } from "./select/getEffectiveValueFromOptionElementProps";
 
-export type OptionProps = Omit<
-  React.DetailedHTMLProps<
-    React.OptionHTMLAttributes<HTMLOptionElement>,
-    HTMLOptionElement
-  >,
-  "children"
-> & { children: string };
+export type OptionProps = React.DetailedHTMLProps<
+  React.OptionHTMLAttributes<HTMLOptionElement>,
+  HTMLOptionElement
+>;
 interface ListItemWrapperProps {
   /** `items` prop passed to `useSelect`
    *
@@ -316,10 +314,9 @@ export const Select: React.FC<Props> = ({
         return value === (item.value ?? item.children);
       }) ?? null,
     onSelectedItemChange: (event) => {
-      const newValue =
-        event.selectedItem?.value?.toString() ??
-        event.selectedItem?.children ??
-        "";
+      const newValue = event.selectedItem
+        ? getEffectiveValueFromOptionElementProps(event.selectedItem)
+        : "";
 
       if (onChange) {
         // This is kind of hacky because there's no underlying `select` with
@@ -386,11 +383,9 @@ export const Select: React.FC<Props> = ({
                         downshiftItems={items}
                         element={child}
                         getItemProps={getItemProps}
-                        key={
-                          child.props.value
-                            ? child.props.value.toString()
-                            : child.props.children
-                        }
+                        key={getEffectiveValueFromOptionElementProps(
+                          child.props,
+                        )}
                       />
                     );
                   } else if (isHTMLOptgroupElement(child)) {
@@ -413,11 +408,9 @@ export const Select: React.FC<Props> = ({
                           (optgroupChild) => {
                             return (
                               <ListItemWrapper
-                                key={
-                                  optgroupChild.props.value
-                                    ? optgroupChild.props.value.toString()
-                                    : optgroupChild.props.children
-                                }
+                                key={getEffectiveValueFromOptionElementProps(
+                                  optgroupChild.props,
+                                )}
                                 downshiftItems={items}
                                 element={optgroupChild}
                                 getItemProps={getItemProps}

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -83,7 +83,10 @@ interface Props
       React.ComponentProps<typeof Button>,
       "aria-labelledby" | "aria-describedby" | "feel" | "style"
     >,
-    Pick<React.ComponentProps<typeof ListConfigProvider>, "margin">,
+    Pick<
+      React.ComponentProps<typeof ListConfigProvider>,
+      "margin" | "truncate"
+    >,
     Pick<
       React.DetailedHTMLProps<
         React.SelectHTMLAttributes<HTMLSelectElement>,
@@ -198,6 +201,7 @@ export const Select: React.FC<Props> = ({
   renderTriggerNode = (value) => <>{value?.children || ""}</>,
   size = "standard",
   triggerAs = <Button />,
+  truncate = true,
   value: valueProp,
   ...props
 }) => {
@@ -359,6 +363,7 @@ export const Select: React.FC<Props> = ({
               listAs,
               {
                 margin,
+                truncate,
                 ...getMenuProps(undefined, { suppressRefError: true }),
                 ...(id && { id: `${id}-menu` }),
                 "aria-labelledby": labelledBy,

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -83,6 +83,7 @@ interface Props
       React.ComponentProps<typeof Button>,
       "aria-labelledby" | "aria-describedby" | "feel" | "style"
     >,
+    Pick<React.ComponentProps<typeof ListConfigProvider>, "margin">,
     Pick<
       React.DetailedHTMLProps<
         React.SelectHTMLAttributes<HTMLSelectElement>,
@@ -188,6 +189,7 @@ export const Select: React.FC<Props> = ({
   feel,
   labelPropsCallbackRef,
   listAs = <List />,
+  margin = "auto",
   matchTriggerWidth,
   onBlur,
   onChange,
@@ -356,6 +358,7 @@ export const Select: React.FC<Props> = ({
             content={React.cloneElement(
               listAs,
               {
+                margin,
                 ...getMenuProps(undefined, { suppressRefError: true }),
                 ...(id && { id: `${id}-menu` }),
                 "aria-labelledby": labelledBy,

--- a/src/Select/select/getEffectiveValueFromOptionElementProps.ts
+++ b/src/Select/select/getEffectiveValueFromOptionElementProps.ts
@@ -1,0 +1,35 @@
+type OptionProps = React.DetailedHTMLProps<
+  React.OptionHTMLAttributes<HTMLOptionElement>,
+  HTMLOptionElement
+>;
+
+/**
+ * Return the effective `value` of an `option` element
+ *
+ * If the `value` prop is found; then it will be stringified and returned.
+ *
+ * If there is no `value` prop and `children` is stringifiable (it's a `string`,
+ * `number`, or `null`), then return the stringiifed `children`. We
+ * intentionally exclude `undefined` here to prevent accidents.
+ *
+ * Otherwise throw an error.
+ */
+export function getEffectiveValueFromOptionElementProps(
+  props: OptionProps,
+): string {
+  if (Object.prototype.hasOwnProperty.call(props, "value")) {
+    return String(props.value);
+  }
+
+  if (
+    typeof props.children === "string" ||
+    typeof props.children === "number" ||
+    props.children == null
+  ) {
+    return String(props.children);
+  }
+
+  throw new TypeError(
+    "All `option` children of `Select` are expected to have either a `value` prop or a `children` prop that is can be interpreted as a `string`",
+  );
+}

--- a/src/Select/select/reactNodeToDownshiftItems.spec.tsx
+++ b/src/Select/select/reactNodeToDownshiftItems.spec.tsx
@@ -19,6 +19,28 @@ it("should work with options with no `value` props", () => {
   `);
 });
 
+it("when passed top-level `option` with no value prop and a non-string children, should throw TypeError", () => {
+  expect(() =>
+    reactNodeToDownshiftItems([
+      <option key="a">
+        <div>a</div>
+      </option>,
+    ]),
+  ).toThrowError(TypeError);
+});
+
+it("when passed option nested under an `optGroup` with the option having no value prop and a non-string children, should throw TypeError", () => {
+  expect(() =>
+    reactNodeToDownshiftItems([
+      <optgroup key="a" label="label a">
+        <option key="a">
+          <div>a</div>
+        </option>
+      </optgroup>,
+    ]),
+  ).toThrowError(TypeError);
+});
+
 it("should work with options with `value` props", () => {
   expect(
     reactNodeToDownshiftItems([

--- a/src/Select/select/reactNodeToDownshiftItems.ts
+++ b/src/Select/select/reactNodeToDownshiftItems.ts
@@ -1,13 +1,10 @@
 import React from "react";
 import { render } from "react-dom";
 
-type OptionProps = Omit<
-  React.DetailedHTMLProps<
-    React.OptionHTMLAttributes<HTMLOptionElement>,
-    HTMLOptionElement
-  >,
-  "children"
-> & { children: string };
+type OptionProps = React.DetailedHTMLProps<
+  React.OptionHTMLAttributes<HTMLOptionElement>,
+  HTMLOptionElement
+>;
 
 type OptgroupProps = React.DetailedHTMLProps<
   React.OptgroupHTMLAttributes<HTMLOptGroupElement>,
@@ -62,6 +59,21 @@ export function isHTMLOptgroupElement(
   return renderHTML(element) instanceof HTMLOptGroupElement;
 }
 
+function validateOptionProps(
+  element: React.ReactElement<OptionProps, "option">,
+): OptionProps {
+  if (
+    Object.prototype.hasOwnProperty.call(element.props, "value") ||
+    typeof element.props.children === "string"
+  ) {
+    return element.props;
+  }
+
+  throw new TypeError(
+    "All `option`s in a `Select` are required to have a `value` set or have `children` be a string to imply a value.",
+  );
+}
+
 /**
  * Convert a `children` prop rendered with `<optgroup><option /></optgroup>` and
  * `<option />` elements into an array of the props of each of those `option`
@@ -73,7 +85,7 @@ export function reactNodeToDownshiftItems(
   return React.Children.toArray(children).reduce<OptionProps[]>(
     (accumulator, child) => {
       if (isHTMLOptionElement(child)) {
-        return accumulator.concat(child.props);
+        return accumulator.concat(validateOptionProps(child));
       }
 
       if (!React.isValidElement(child)) {
@@ -83,7 +95,7 @@ export function reactNodeToDownshiftItems(
       return accumulator.concat(
         React.Children.toArray(child.props.children)
           .filter(isHTMLOptionElement)
-          .map((optgroupChild) => optgroupChild.props),
+          .map((optgroupChild) => validateOptionProps(optgroupChild)),
       );
     },
     [],

--- a/src/shared/cloneElements.tsx
+++ b/src/shared/cloneElements.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classnames from "classnames";
 import { ClassNames } from "@emotion/core";
 
 /**
@@ -16,15 +15,13 @@ export const cloneElements = (
         return elements.reduce((accumulator, element) => {
           return React.cloneElement(accumulator, {
             ...element.props,
-            className: classnames(
+            className: cx(
               element.props.className,
               accumulator.props.className,
               // If the parent component is using emotion with the jsx pragma, we
               // have to get fancy and intercept the styles to use with the
               // `ClassNames` wrapper.
-              accumulator.props.css
-                ? cx(css(accumulator.props.css.styles))
-                : null,
+              accumulator.props.css ? css(accumulator.props.css.styles) : null,
             ),
             style: { ...element.props.style, ...accumulator.props.style },
             // Since we're cloning `as` with the `original` props added, we're


### PR DESCRIPTION
## Reviewing

A cursory glance would be fine. I don't think there's anything controversial here and the functionality is well-tested. The documentation will require some improvements, but that won't block the release.

## Release Notes

* Add borderless appearance to `Select` and `List` with `margin="none"`
* Add `truncate` prop to `Select` and `List`

  Defaults to `true`. Set this to `false` to enable multi-line items.

* Add `selectionIndicator` to `Select` to show checkmarks for selected items
* Stop rendering `ListHeading` in `Select` `optgroup` if there is no `label`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.9.1-canary.293.7464.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.9.1-canary.293.7464.0
  # or 
  yarn add @apollo/space-kit@8.9.1-canary.293.7464.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
