### PR TITLE
Input component forward ref to HTML input element

### DIFF
--- a/src/Input/index.tsx
+++ b/src/Input/index.tsx
@@ -55,59 +55,58 @@ interface Props
  * to either the containing `div` or the underlying `input`, you must use
  * `containerAs` and `inputAs`.
  */
-export const Input: React.FC<Props> = ({
-  size = "standard",
-  type = "text",
-  ...props
-}) => {
-  const {
-    describedBy,
-    endAdornment,
-    labelledBy,
-    hasError,
-    id,
-    startAdornment,
-  } = useFormControlContext();
+export const Input = React.forwardRef<HTMLInputElement, Props>(
+  ({ size = "standard", type = "text", ...props }, ref) => {
+    const {
+      describedBy,
+      endAdornment,
+      labelledBy,
+      hasError,
+      id,
+      startAdornment,
+    } = useFormControlContext();
 
-  return (
-    <input
-      id={id}
-      aria-labelledby={labelledBy}
-      aria-describedby={describedBy}
-      aria-invalid={hasError || undefined}
-      type={type}
-      {...props}
-      css={css({
-        backgroundColor: props.disabled ? colors.silver.light : colors.white,
-        border: "solid 1px",
-        borderColor: hasError ? colors.red.base : colors.silver.darker,
-        "::placeholder": {
-          color: props.disabled ? colors.grey.lighter : colors.grey.light,
-          opacity: 1,
-        },
-        borderRadius: 4,
-        flex: 1,
-        height: inputHeightDictionary[size],
-        ...(size === "small" ? typography.base.small : typography.base.base),
-        paddingLeft: startAdornment ? 34 : size === "small" ? 8 : 10,
-        paddingRight: endAdornment ? 34 : size === "small" ? 8 : 10,
-        width: "100%",
-        ":hover,  &[data-force-hover-state]": {
-          borderColor: !props.disabled
-            ? colors.grey.light
-            : hasError
-            ? colors.red.base
-            : colors.silver.darker,
-        },
-        ":focus, &[data-force-focus-state]": {
-          borderColor: !props.disabled
-            ? colors.blue.light
-            : hasError
-            ? colors.red.base
-            : colors.silver.darker,
-          outline: "none",
-        },
-      })}
-    />
-  );
-};
+    return (
+      <input
+        ref={ref}
+        id={id}
+        aria-labelledby={labelledBy}
+        aria-describedby={describedBy}
+        aria-invalid={hasError || undefined}
+        type={type}
+        {...props}
+        css={css({
+          backgroundColor: props.disabled ? colors.silver.light : colors.white,
+          border: "solid 1px",
+          borderColor: hasError ? colors.red.base : colors.silver.darker,
+          "::placeholder": {
+            color: props.disabled ? colors.grey.lighter : colors.grey.light,
+            opacity: 1,
+          },
+          borderRadius: 4,
+          flex: 1,
+          height: inputHeightDictionary[size],
+          ...(size === "small" ? typography.base.small : typography.base.base),
+          paddingLeft: startAdornment ? 34 : size === "small" ? 8 : 10,
+          paddingRight: endAdornment ? 34 : size === "small" ? 8 : 10,
+          width: "100%",
+          ":hover,  &[data-force-hover-state]": {
+            borderColor: !props.disabled
+              ? colors.grey.light
+              : hasError
+              ? colors.red.base
+              : colors.silver.darker,
+          },
+          ":focus, &[data-force-focus-state]": {
+            borderColor: !props.disabled
+              ? colors.blue.light
+              : hasError
+              ? colors.red.base
+              : colors.silver.darker,
+            outline: "none",
+          },
+        })}
+      />
+    );
+  },
+);


### PR DESCRIPTION
This wraps `Input` in `React.forwardRef` so it can be used as a trigger in `Popover`
This enables us to do a POC of a combo box

Review with whitespace turned off.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.10.1-canary.296.7499.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.10.1-canary.296.7499.0
  # or 
  yarn add @apollo/space-kit@8.10.1-canary.296.7499.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
