### PR TITLE
AR-1993 Replace `Select` custom blue highlighting with silver

### DIFF
--- a/src/Select/SelectTests.story.tsx
+++ b/src/Select/SelectTests.story.tsx
@@ -45,4 +45,43 @@ storiesOf("Tests/Select", module)
     {
       chromatic: { delay: 200 },
     },
+  )
+  .add(
+    "long list",
+    () => (
+      <div
+        className="sk-scroll-container"
+        style={{
+          height: 300,
+          width: 300,
+          border: "1px solid red",
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        <PerformUserInteraction
+          callback={async () => {
+            // Click the triggering button
+            userEvent.click(await findByRole(document.body, "button"));
+          }}
+        >
+          <Select>
+            {["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"].map(
+              (groupLabel) => (
+                <optgroup key={groupLabel} label={groupLabel}>
+                  {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((optValue) => (
+                    <option key={optValue} value={optValue}>
+                      {optValue}
+                    </option>
+                  ))}
+                </optgroup>
+              ),
+            )}
+          </Select>
+        </PerformUserInteraction>
+      </div>
+    ),
+    {
+      chromatic: { delay: 200 },
+    },
   );

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -68,7 +68,8 @@ const ListItemWrapper: React.FC<ListItemWrapperProps> = ({
       css={{ alignItems: "baseline" }}
       key={element.props.value || element.props.children}
       {...downshiftItemProps}
-      selected={downshiftItemProps["aria-selected"] === "true"}
+      highlighted={downshiftItemProps["aria-selected"] === "true"}
+      selected={selected}
       startIcon={
         selectionIndicator === "checkmark" ? (
           selected ? (
@@ -375,7 +376,7 @@ export const Select: React.FC<Props> = ({
   }, [labelProps, labelPropsCallbackRef]);
 
   return (
-    <ListConfigProvider {...listConfig} hoverColor={null} iconSize="small">
+    <ListConfigProvider {...listConfig} iconSize="small">
       <ClassNames>
         {({ css, cx }) => (
           <Popover


### PR DESCRIPTION
We have custom logic to use blue highlights when scrolling with the keyboard or hovering with the mouse. This is a departure from the list behavior we've been using; so this will replace that.

AR-1993
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.11.1-canary.297.7532.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.11.1-canary.297.7532.0
  # or 
  yarn add @apollo/space-kit@8.11.1-canary.297.7532.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
