### PR TITLE
AR-2016 Allow `Tooltip` to wrap a `Button` that is `disabled`

### DIFF
--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -1,10 +1,16 @@
 import "@testing-library/jest-dom";
 import * as faker from "faker";
-import { Button } from "./Button";
+import { Button } from "../Button";
+import { Tooltip } from "../Tooltip";
 import { act, render, screen } from "@testing-library/react";
 import { IconShip2 } from "../icons/IconShip2";
 import React from "react";
 import userEvent from "@testing-library/user-event";
+import { matchers } from "jest-emotion";
+import { colors } from "../colors";
+
+// Add the custom matchers provided by 'jest-emotion'
+expect.extend(matchers);
 
 test("default button renders", () => {
   render(<Button>submit</Button>);
@@ -77,6 +83,52 @@ test("when disabled, button does not call click handlers", () => {
   // assert
   expect(asElementOnClick).not.toHaveBeenCalled();
   expect(rootElementOnClick).not.toHaveBeenCalled();
+});
+
+test("when wrapped in a Tooltip, disabled, hovered, disabled style is rendered", async () => {
+  render(
+    <Tooltip content="tooltip">
+      <Button disabled>button</Button>
+    </Tooltip>,
+  );
+
+  screen.debug(document);
+  const button = screen.getByRole("button");
+  expect(button).toHaveStyleRule("background-color", colors.silver.light);
+
+  // Wait for the tooltip to appear
+  userEvent.hover(button);
+  await screen.findByText("tooltip");
+
+  expect(button).toHaveStyleRule("background-color", colors.silver.light);
+});
+
+test("when wrapped in a Tooltip, disabled, hovered, Tooltip content is visible", async () => {
+  render(
+    <Tooltip content="tooltip">
+      <Button disabled>button</Button>
+    </Tooltip>,
+  );
+
+  userEvent.hover(screen.getByRole("button"));
+
+  await screen.findByText("tooltip");
+});
+
+test("when not wrapped in a Tooltip, disabled prop is applied to DOM", () => {
+  render(<Button disabled>button</Button>);
+
+  expect(screen.getByRole("button")).toBeDisabled();
+});
+
+test("when wrapped in a Tooltip, disabled prop is applied to DOM", () => {
+  render(
+    <Tooltip content="tooltip">
+      <Button disabled>button</Button>
+    </Tooltip>,
+  );
+
+  expect(screen.getByRole("button")).toBeDisabled();
 });
 
 test("when disabled, button with 'as=' set to not a button element does not call click handlers", () => {

--- a/src/Button/Button.stories.mdx
+++ b/src/Button/Button.stories.mdx
@@ -1,4 +1,5 @@
 import { Button } from "./Button";
+import { Tooltip } from "../Tooltip";
 import { Meta, Story, ArgsTable, Canvas } from "@storybook/addon-docs/blocks";
 import { IconExpandList } from "../icons/IconExpandList";
 import { IconShip2 } from "../icons/IconShip2";
@@ -770,6 +771,30 @@ Showing how we could potentially use color with the simple button.
     </div>
   </Story>
 </Canvas>
+
+### Disabled Buttons
+
+Disabled buttons wrapped with a `Tooltip` will behave slightly differently to enable the `Tooltip` to be displayed. The only user-facing behavior change will be that the `disabled` prop will not be rendered in the DOM when the tooltip is visible.
+
+<Story name="disabled with tooltip">
+  <style>{`
+    .mt-4 { margin-top: 1rem }
+  `}</style>
+  <Tooltip content="tooltip">
+    <Button className="mt-4" disabled>
+      Button
+    </Button>
+  </Tooltip>
+</Story>
+
+<Story name="enabled with tooltip">
+  <style>{`
+    .mt-4 { margin-top: 1rem }
+  `}</style>
+  <Tooltip content="tooltip">
+    <Button className="mt-4">Button</Button>
+  </Tooltip>
+</Story>
 
 ## Props
 

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { mouseRest } from "./tooltip/mouseRestPlugin";
 import { AbstractTooltip, AbstractTooltipProps } from "../AbstractTooltip";
+import { TooltipContextProvider } from "../shared/TooltipContext";
 
 type Props = Pick<
   React.ComponentProps<typeof AbstractTooltip>,
@@ -22,13 +23,15 @@ type Props = Pick<
  */
 export const Tooltip: React.FC<Props> = ({ children, ...props }) => {
   return (
-    <AbstractTooltip
-      delay={150}
-      trigger="mouseenter"
-      plugins={[mouseRest]}
-      {...props}
-    >
-      {children}
-    </AbstractTooltip>
+    <TooltipContextProvider descendsFromTooltip>
+      <AbstractTooltip
+        delay={150}
+        trigger="mouseenter"
+        plugins={[mouseRest]}
+        {...props}
+      >
+        {children}
+      </AbstractTooltip>
+    </TooltipContextProvider>
   );
 };

--- a/src/shared/TooltipContext.tsx
+++ b/src/shared/TooltipContext.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+interface State {
+  descendsFromTooltip: boolean;
+}
+
+const defaultState: State = {
+  descendsFromTooltip: false,
+};
+
+const TooltipContext = React.createContext<State | undefined>(undefined);
+
+/**
+ * Component to indicate to descentent components that they are wrapped by a
+ * `Tooltip`.
+ */
+export const TooltipContextProvider: React.FC<Partial<State>> = ({
+  children,
+  descendsFromTooltip,
+}) => {
+  const state = React.useMemo(
+    () => ({
+      descendsFromTooltip:
+        descendsFromTooltip ?? defaultState.descendsFromTooltip,
+    }),
+    [descendsFromTooltip],
+  );
+
+  return (
+    <TooltipContext.Provider value={state}>{children}</TooltipContext.Provider>
+  );
+};
+
+/**
+ * Hook to extract values of `TooltipContext` with defaults applied.
+ *
+ * This will _not_ `throw` if used outside of a `TooltipContextProvider`.
+ */
+export function useTooltipContext(): State {
+  return React.useContext(TooltipContext) ?? defaultState;
+}


### PR DESCRIPTION
This works by capturing pointer events to signal that the cursor is over the button and then applying `disabled` styles directly to the `button` element and removing the `disabled` property so that tippy.js will show the tooltip. I went with this approach because then we can still test for `disabled` buttons.

AR-2016

Testing to see how this looks in Studio UI https://github.com/mdg-private/studio-ui/pull/3700

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.12.1-canary.298.7907.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.12.1-canary.298.7907.0
  # or 
  yarn add @apollo/space-kit@8.12.1-canary.298.7907.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
