### PR TITLE
CI: show only lint errors, not warnings, when Ci fails for linting er…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: mkdir -p /tmp/test-reports/eslint
       - run:
           name: Eslint
-          command: npm run lint -- --no-cache --format junit --output-file /tmp/test-reports/eslint/results.xml
+          command: npm run lint -- --quiet --no-cache --format junit --output-file /tmp/test-reports/eslint/results.xml
       - store_test_results:
           path: /tmp/test-reports
 


### PR DESCRIPTION
…rors
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.11.1-canary.299.7563.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.11.1-canary.299.7563.0
  # or 
  yarn add @apollo/space-kit@8.11.1-canary.299.7563.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
