### PR TITLE
AP-1948 Add `renderListItem` prop to `Select`

### DIFF
--- a/src/Select/Select.spec.tsx
+++ b/src/Select/Select.spec.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { act, render, screen, within, waitFor } from "@testing-library/react";
+import { ListItem } from "../ListItem";
 import { Select } from "../Select";
 import { SpaceKitProvider } from "../SpaceKitProvider";
 import { FormikConfig, useFormik } from "formik";
@@ -63,6 +64,31 @@ test("given a controlled `value`, should render controlled value", () => {
   expect(screen.getByText("a")).toBeInTheDocument();
   expect(screen.queryByText("b")).not.toBeInTheDocument();
   act(() => userEvent.click(screen.getByRole("button")));
+});
+
+test("given a `renderListItem` prop, should be used", () => {
+  render(
+    <SpaceKitProvider disableAnimations>
+      <Select
+        renderListItem={(props, optionElement) => (
+          <ListItem
+            {...props}
+            as={<a href={`/${String(optionElement.props.value)}`} />}
+          />
+        )}
+        value="a"
+      >
+        <option value="a">a</option>
+        <option value="b">b</option>
+      </Select>
+    </SpaceKitProvider>,
+  );
+
+  userEvent.click(screen.getByRole("button", { name: "a" }));
+
+  const option = screen.getByRole("option", { name: "b" });
+  expect(option.tagName.toLowerCase()).toBe("a");
+  expect(option).toHaveAttribute("href", "/b");
 });
 
 test("given children mixed with `option` and `optgroup`, should render headings and elements", () => {


### PR DESCRIPTION
This will allow us to customize how the `ListItem` is rendered by `Select`,
allowing us to use something like `react-router`'s `Link`

AP-1948

Tested in Studio UI https://github.com/mdg-private/studio-ui/pull/3672

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.11.2-canary.300.7827.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.11.2-canary.300.7827.0
  # or 
  yarn add @apollo/space-kit@8.11.2-canary.300.7827.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
