### PR TITLE
Try to remove post-animation pixel shift in Tooltip, ConfirmationTooltip, and Menu stories

### DIFF
--- a/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
+++ b/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
@@ -8,10 +8,6 @@ export const TippyStyles: React.FC = () => (
   <Global
     styles={css({
       ".tippy-box": {
-        // We need this to anticipate sub-pixel shifting between the animated
-        // and non-animated state.
-        "will-change": "transform",
-
         "&[data-theme=space-kit]": {
           ...base.small,
           backgroundColor: colors.black.base,
@@ -36,6 +32,32 @@ export const TippyStyles: React.FC = () => (
 
           "&.space-kit-relaxed .tippy-content": {
             padding: "8px 12px",
+          },
+        },
+
+        "&[data-animation=shift-away]": {
+          "will-change": "transform",
+
+          transform: "rotate(0.0001deg) ",
+
+          "&[data-state=hidden]": {
+            opacity: 0,
+
+            "&[data-placement^=top]": {
+              transform: "translateY(10px), rotate(0.0001deg) ",
+            },
+
+            "&[data-placement^=bottom]": {
+              transform: "translateY(-10px), rotate(0.0001deg) ",
+            },
+
+            "&[data-placement^=left]": {
+              transform: "translateX(10px), rotate(0.0001deg) ",
+            },
+
+            "&[data-placement^=right]": {
+              transform: "translateX(-10px), rotate(0.0001deg) ",
+            },
           },
         },
       },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.11.1-canary.302.7683.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.11.1-canary.302.7683.0
  # or 
  yarn add @apollo/space-kit@8.11.1-canary.302.7683.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
