### PR TITLE
add size debugging to tooltip stories

### DIFF
--- a/src/shared/DebugTooltip.tsx
+++ b/src/shared/DebugTooltip.tsx
@@ -20,9 +20,17 @@ export const DebugTooltip: React.FC = ({ children }) => {
 
         getByTestId(document.body, "debug-styles-box").appendChild(
           document.createTextNode(
-            `${tippyRoot.style.transform}\nclientWidth=${
-              document.querySelector("html")?.clientWidth
-            }`,
+            [
+              `${tippyRoot.style.transform}`,
+              `clientWidth=${document.querySelector("html")?.clientWidth}`,
+              `size=${
+                document.querySelector<HTMLDivElement>("[data-tippy-root]")
+                  ?.offsetWidth
+              }x${
+                document.querySelector<HTMLDivElement>("[data-tippy-root]")
+                  ?.offsetHeight
+              }`,
+            ].join("\n"),
           ),
         );
       }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.11.2-canary.304.7810.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.11.2-canary.304.7810.0
  # or 
  yarn add @apollo/space-kit@8.11.2-canary.304.7810.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
