### PR TITLE
fix(Modal): Fix repeating animations with custom components

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -180,8 +180,13 @@ export const Modal: React.FC<Props> = ({
    * We have to strip the type because we'll get an error about the union being
    * too complex to model because `motion` has over 100 options.
    */
-  const MotionComponent: React.ComponentType<MotionProps> =
-    typeof type === "string" ? motion[type] : motion.custom<MotionProps>(type);
+  const MotionComponent: React.ComponentType<MotionProps> = React.useMemo(
+    () =>
+      typeof type === "string"
+        ? motion[type]
+        : motion.custom<MotionProps>(type),
+    [type],
+  );
 
   return (
     <ClassNames>


### PR DESCRIPTION
Re-running `motion.custom(type)` on every render results in a new component on every render. When we render this with `React.createElement` (which is what `<MotionComponent>` does under the hood), this will cause the `<MotionComponent>` to destroy and create a new DOM element on every render. Why? `React.createElement` verifies that the component being rendered (`type`) is the same from render-to-render before doing a DOM diff to see if there is a change. In other words, if the `type` changes from one render to the next, React will assume you don't want to re-use the existing DOM and will destroy and re-create it.

I installed the canary in Studio UI to see if would fix the e2e and unit tests; it does! https://app.circleci.com/pipelines/github/mdg-private/studio-ui/26973/workflows/4323c9e1-9267-4fa6-8a00-a9055b5a6907

The solution? Simply memoize `MotionType` based on `type`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.2-canary.308.8001.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.13.2-canary.308.8001.0
  # or 
  yarn add @apollo/space-kit@8.13.2-canary.308.8001.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
