### PR TITLE
Tweak modal page background color

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -98,8 +98,8 @@ const modalBackdrop = css`
     position: fixed;
     z-index: 10;
     content: "";
-    background-color: ${colors.grey.lighter};
-    opacity: 0.7;
+    background-color: ${colors.black.base};
+    opacity: 0.55;
     top: 0;
     left: 0;
     bottom: 0;


### PR DESCRIPTION
This PR tweaks the modal page background color, making it slightly darker to increase the contrast of the modal. This also makes consistency with the spotlight search page background, which is already using this color tone.

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/1319791/107279777-54376380-6a0c-11eb-90c4-ae710277b1da.png)|![image](https://user-images.githubusercontent.com/1319791/107279807-5f8a8f00-6a0c-11eb-8da1-8807a25d2289.png)|
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.3-canary.309.8038.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.13.3-canary.309.8038.0
  # or 
  yarn add @apollo/space-kit@8.13.3-canary.309.8038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
