### PR TITLE
AR-2064 Resolve issue where `ListDivider` overflows container

### DIFF
--- a/src/List/index.tsx
+++ b/src/List/index.tsx
@@ -15,6 +15,13 @@ interface Props
       "style" | "className"
     > {}
 
+/**
+ * Indicates how much padding the default tooltip has
+ *
+ * This will be used to apply negative margins to elements.
+ */
+export const listPadding = 6;
+
 export const List = React.forwardRef<
   HTMLDivElement,
   React.PropsWithChildren<Props>
@@ -61,7 +68,7 @@ export const List = React.forwardRef<
         : assertUnreachable(listConfig.margin));
     const horizontalMargin =
       listConfig.margin === "none"
-        ? -6
+        ? -listPadding
         : listConfig.margin === "auto"
         ? 0
         : assertUnreachable(listConfig.margin);

--- a/src/ListDivider/index.tsx
+++ b/src/ListDivider/index.tsx
@@ -1,13 +1,18 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
 /** @jsx jsx */
 import React from "react";
 import { css, jsx } from "@emotion/core";
 import { colors } from "../colors";
+import { ListItem } from "../ListItem";
+import { useListConfig, ListConfigProvider } from "../ListConfig";
+import { listPadding } from "../List";
+import { assertUnreachable } from "../shared/assertUnreachable";
 
 /**
  * Divider between sections in a list
  */
 export const ListDivider: React.FC = (props) => {
+  const listConfig = useListConfig();
+
   // Stop click events so we don't try to close the list when clicking something
   // non-interactive
   const handleClick = React.useCallback<React.MouseEventHandler<HTMLHRElement>>(
@@ -18,22 +23,49 @@ export const ListDivider: React.FC = (props) => {
     [],
   );
 
+  /**
+   * Indicates how much negative space we need to take to make sure the divider
+   * goes edge-to-edge
+   */
+  const horizontalOffset =
+    listConfig.margin === "auto"
+      ? -listPadding
+      : listConfig.margin === "none"
+      ? 0
+      : assertUnreachable(listConfig.margin);
+
   return (
-    <hr
-      {...props}
-      onClick={handleClick}
-      css={css({
-        marginLeft: -8,
-        marginRight: -8,
-        marginTop: 8,
-        marginBottom: 8,
-        borderTopColor: colors.silver.base,
-        borderTopWidth: 1,
-        borderTopStyle: "solid",
-        borderBottomWidth: 0,
-        borderLeftWidth: 0,
-        borderRightWidth: 0,
-      })}
-    />
+    <ListConfigProvider truncate={false}>
+      <ListItem
+        interactive={false}
+        css={css({
+          alignItems: "stretch",
+          justifyItems: "center",
+          paddingLeft: 0,
+          paddingRight: 0,
+          position: "relative",
+          height: 17,
+        })}
+      >
+        <hr
+          {...props}
+          onClick={handleClick}
+          css={{
+            borderBottomWidth: 0,
+            borderLeftWidth: 0,
+            borderRightWidth: 0,
+            borderTopColor: colors.silver.base,
+            borderTopStyle: "solid",
+            borderTopWidth: 1,
+            bottom: 0,
+            left: horizontalOffset,
+            margin: 0,
+            position: "absolute",
+            right: horizontalOffset,
+            top: 8,
+          }}
+        />
+      </ListItem>
+    </ListConfigProvider>
   );
 };


### PR DESCRIPTION
AR-2064

The overflowing `ListDivider` caused `List` to horizontally scroll. There was a fix in place in Studio UI; but that breaks the ability to nest tooltips. This resolves the root issue by absolutely positioning the `hr` in `ListDivider` so it no longer is considered for scroll behavior.

## Testing

You can see the wrong behavior [here](https://5d5186efdf7d2d00203d4434-lkokyphsqb.chromatic.com/?path=/story/form-select--feel-raised). Visit this story, try to scroll horizontally. You'll see it's possible, but it shouldn't be.

You can verify the correct behavior in the deploy preview [here]().
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.14.1-canary.312.8165.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.14.1-canary.312.8165.0
  # or 
  yarn add @apollo/space-kit@8.14.1-canary.312.8165.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
