### PR TITLE
Pass `disabled` prop from options to downshift in `Select`

### DIFF
--- a/src/Select/Select.story.mdx
+++ b/src/Select/Select.story.mdx
@@ -90,6 +90,19 @@ You must use the same `<option>` and `<optgroup>` elements you would use for a n
       <option value="value b">b</option>
     </Select>
   </Story>
+  <Story name="disabled option">
+    <Select
+      renderTriggerNode={(selectedItem) => (
+        <>{selectedItem?.children ?? "select an item"}</>
+      )}
+    >
+      <option value="value a" disabled>
+        a
+      </option>
+      <option value="value b">b</option>
+      <option value="value c">c</option>
+    </Select>
+  </Story>
 </Canvas>
 
 ## Custom content

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -104,6 +104,7 @@ const ListItemWrapper: React.FC<ListItemWrapperProps> = ({
   const downshiftItemProps = getItemProps({
     item: element.props,
     index: downshiftItems.indexOf(element.props),
+    disabled: element.props.disabled,
   });
 
   return (


### PR DESCRIPTION
This connects the disabled prop on an `<option/>` in Select to downshift so the option will not be selectable.
This is needed to have options displayed in the list that are disabled for permission reasons.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.1-canary.315.8309.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.16.1-canary.315.8309.0
  # or 
  yarn add @apollo/space-kit@8.16.1-canary.315.8309.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
