### PR TITLE
FeatureIntro: add padding to increase click target

### DIFF
--- a/src/FeatureIntroContent/index.tsx
+++ b/src/FeatureIntroContent/index.tsx
@@ -42,6 +42,7 @@ export const FeatureIntroContent: React.FC<Props> = ({
           color: colors.grey.base,
           fontWeight: "normal",
           lineHeight: "16px",
+          paddingBottom: 16,
         }}
         id={featureIntroId && `${featureIntroId}-content`}
         style={style}

--- a/src/FeatureIntroControl/index.tsx
+++ b/src/FeatureIntroControl/index.tsx
@@ -150,7 +150,6 @@ const FeatureIntroControl: React.FC<FeatureIntroControlProps> = ({
               {content}
               <div
                 css={css({
-                  paddingTop: 16,
                   display: "flex",
                   justifyContent: "space-between",
                 })}

--- a/src/FeatureIntroDismissButton/index.tsx
+++ b/src/FeatureIntroDismissButton/index.tsx
@@ -43,6 +43,9 @@ export const FeatureIntroDismissButton: React.FC<Props> = ({
           ...typography.base.small,
           color: colors.blue.base,
           fontWeight: 600,
+          padding: "8px 5px",
+          marginRight: -5,
+          marginTop: -8,
           // force right even if there is no learn more button
           marginLeft: "auto",
           cursor: "pointer",

--- a/src/FeatureIntroLearnMoreLink/index.tsx
+++ b/src/FeatureIntroLearnMoreLink/index.tsx
@@ -52,6 +52,9 @@ export const FeatureIntroLearnMoreLink: React.FC<Props> = ({
                   color: colors.grey.base,
                   ...typography.base.small,
                   fontWeight: 600,
+                  padding: "8px 5px",
+                  marginLeft: -5,
+                  marginTop: -8,
                 }}
               >
                 Learn more


### PR DESCRIPTION
[per request from Chang](https://github.com/mdg-private/studio-ui/pull/3763#discussion_r576504053)

Can't add more padding because the dimensions will be off
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.2-canary.316.8354.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.16.2-canary.316.8354.0
  # or 
  yarn add @apollo/space-kit@8.16.2-canary.316.8354.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
