### PR TITLE
Expose color prop for elect trigger

### DIFF
--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -143,7 +143,7 @@ interface Props
     >,
     Pick<
       React.ComponentProps<typeof Button>,
-      "aria-labelledby" | "aria-describedby" | "feel" | "style"
+      "aria-labelledby" | "aria-describedby" | "feel" | "style" | "color"
     >,
     Pick<
       React.ComponentProps<typeof ListConfigProvider>,
@@ -265,6 +265,7 @@ export const Select: React.FC<Props> = ({
   defaultValue,
   disabled = false,
   feel,
+  color,
   labelPropsCallbackRef,
   listAs = <List startIconAs={<div css={{ alignSelf: "baseline" }} />} />,
   margin = "auto",
@@ -564,7 +565,7 @@ export const Select: React.FC<Props> = ({
                   React.isValidElement(triggerAs) &&
                     (triggerAs.props as any).className,
                 ),
-                color: colors.white,
+                color: color ?? colors.white,
                 feel,
                 onBlur() {
                   if (toggleButtonClickTimeout.current) {

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -265,7 +265,7 @@ export const Select: React.FC<Props> = ({
   defaultValue,
   disabled = false,
   feel,
-  color,
+  color = colors.white,
   labelPropsCallbackRef,
   listAs = <List startIconAs={<div css={{ alignSelf: "baseline" }} />} />,
   margin = "auto",

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -565,7 +565,7 @@ export const Select: React.FC<Props> = ({
                   React.isValidElement(triggerAs) &&
                     (triggerAs.props as any).className,
                 ),
-                color: color ?? colors.white,
+                color,
                 feel,
                 onBlur() {
                   if (toggleButtonClickTimeout.current) {


### PR DESCRIPTION
Personally I find in unintuitive that the `color`, `feel`, `size`, etc passed on the `triggerAs` get overwritten. I went with this as the smallest unblocking change, but also happy to switch this to follow props passed to `triggerAs` so we dont need a mix of top level props and `triggerAs` to style a custom trigger.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.18.1-canary.326.8945.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.18.1-canary.326.8945.0
  # or 
  yarn add @apollo/space-kit@8.18.1-canary.326.8945.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
