### PR TITLE
AR-2135 Fix `Select` closing when interactive children receive focus

### DIFF
--- a/src/Popover/index.tsx
+++ b/src/Popover/index.tsx
@@ -10,6 +10,7 @@ interface Props
     | "content"
     | "disabled"
     | "fallbackPlacements"
+    | "hideOnClick"
     | "matchTriggerWidth"
     | "maxWidth"
     | "onCreate"
@@ -44,6 +45,7 @@ interface Props
 export const Popover: React.FC<Props> = ({
   fallbackPlacements,
   content,
+  hideOnClick = true,
   popperOptions,
   trigger,
   triggerEvents = "mousedown",
@@ -86,7 +88,7 @@ export const Popover: React.FC<Props> = ({
           instanceRef.current = instance;
         }}
         content={<span onClick={handleClick}>{content}</span>}
-        hideOnClick
+        hideOnClick={hideOnClick}
         theme="space-kit-list"
         trigger={triggerEvents}
         popperOptions={{

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -358,10 +358,40 @@ export const Select: React.FC<Props> = ({
     getToggleButtonProps,
     selectedItem,
   } = useSelect<OptionProps>({
+    stateReducer(state, actionAndChanges) {
+      switch (actionAndChanges.type) {
+        case useSelect.stateChangeTypes.MenuMouseLeave:
+        case useSelect.stateChangeTypes.MenuBlur: {
+          /**
+           * Indicates if the element that we "blur"'ed to is a descendent of
+           * the tooltip. If it is, then we should bypass the closing behavior.
+           */
+          const popperContainsActiveElement = !!instanceRef.current?.popper?.contains(
+            document.activeElement,
+          );
+
+          return {
+            ...actionAndChanges.changes,
+            isOpen: popperContainsActiveElement,
+          };
+        }
+        default:
+          return actionAndChanges.changes;
+      }
+    },
     onStateChange(changes) {
       switch (changes.type) {
+        case useSelect.stateChangeTypes.MenuMouseLeave:
         case useSelect.stateChangeTypes.MenuBlur: {
-          blur();
+          /**
+           * Indicates if the element that we "blur"'ed to is a descendent of
+           * the tooltip. If it is, then we should bypass the closing behavior.
+           */
+          const popperContainsActiveElement = !!instanceRef.current?.popper?.contains(
+            document.activeElement,
+          );
+
+          if (!popperContainsActiveElement) blur();
           break;
         }
         case useSelect.stateChangeTypes.ToggleButtonClick:
@@ -512,6 +542,7 @@ export const Select: React.FC<Props> = ({
                   return null;
                 }),
             )}
+            hideOnClick={false}
             placement={placement}
             triggerEvents="manual"
             matchTriggerWidth={matchTriggerWidth}


### PR DESCRIPTION
When an interactive child of `Select` is focused, like an `<input />`; `useSelect` will recognize that as a menu blur and will close the menu. This will capture the menu blur and mouse leave events and keep the `Select` open if the `activeElement` (element that has the focus) is a descendent of the underlying tooltip.

AR-2135
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.17.3-canary.327.8663.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.17.3-canary.327.8663.0
  # or 
  yarn add @apollo/space-kit@8.17.3-canary.327.8663.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
