### PR TITLE
AR-2148 Fix repeated rendering of global styles for tooltip-like components

### DIFF
--- a/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
+++ b/src/AbstractTooltip/abstractTooltip/TippyStyles.tsx
@@ -3,38 +3,46 @@ import React from "react";
 import { base } from "../../typography";
 import { colors } from "../../colors";
 import { Global, css } from "@emotion/core";
+import { SingletonComponent } from "../../shared/components/SingletonComponent";
 
 export const TippyStyles: React.FC = () => (
-  <Global
-    styles={css({
-      ".tippy-box": {
-        "&[data-theme=space-kit]": {
-          ...base.small,
-          backgroundColor: colors.black.base,
-          opacity: 0.95,
+  <SingletonComponent identity="src/AbstractTooltip/abstractTooltip/TippyStyles.tsx">
+    {React.useMemo(
+      () => (
+        <Global
+          styles={css({
+            ".tippy-box": {
+              "&[data-theme=space-kit]": {
+                ...base.small,
+                backgroundColor: colors.black.base,
+                opacity: 0.95,
 
-          '&[data-placement^="top"] > .tippy-arrow': {
-            borderTopColor: colors.black.base,
-          },
-          '&[data-placement^="bottom"] > .tippy-arrow': {
-            borderBottomColor: colors.black.base,
-          },
-          '&[data-placement^="right"] > .tippy-arrow': {
-            borderRightColor: colors.black.base,
-          },
-          '&[data-placement^="left"] > .tippy-arrow': {
-            borderLeftColor: colors.black.base,
-          },
+                '&[data-placement^="top"] > .tippy-arrow': {
+                  borderTopColor: colors.black.base,
+                },
+                '&[data-placement^="bottom"] > .tippy-arrow': {
+                  borderBottomColor: colors.black.base,
+                },
+                '&[data-placement^="right"] > .tippy-arrow': {
+                  borderRightColor: colors.black.base,
+                },
+                '&[data-placement^="left"] > .tippy-arrow': {
+                  borderLeftColor: colors.black.base,
+                },
 
-          ".tippy-content": {
-            padding: "4px 8px",
-          },
+                ".tippy-content": {
+                  padding: "4px 8px",
+                },
 
-          "&.space-kit-relaxed .tippy-content": {
-            padding: "8px 12px",
-          },
-        },
-      },
-    })}
-  />
+                "&.space-kit-relaxed .tippy-content": {
+                  padding: "8px 12px",
+                },
+              },
+            },
+          })}
+        />
+      ),
+      [],
+    )}
+  </SingletonComponent>
 );

--- a/src/Popover/popover/TippyPopoverStyles.tsx
+++ b/src/Popover/popover/TippyPopoverStyles.tsx
@@ -3,28 +3,36 @@ import React from "react";
 import { base } from "../../typography";
 import { colors } from "../../colors";
 import { Global, css } from "@emotion/core";
+import { SingletonComponent } from "../../shared/components/SingletonComponent";
 
 export const TippyPopoverStyles: React.FC = () => (
-  <Global
-    styles={css({
-      "*[data-tippy-root]": {},
-      ".tippy-box": {
-        "&[data-theme=space-kit-list]": {
-          ...base.small,
-          boxShadow:
-            "0 3px 4px 0 rgba(18, 21, 26, 0.04), 0 4px 8px 0 rgba(18, 21, 26, 0.08), 0 0 0 1px rgba(18, 21, 26, 0.08)",
-          backgroundColor: colors.white,
-          borderRadius: 4,
-          color: colors.black.base,
-          padding: 6,
-          margin: 2,
-          minWidth: 190,
+  <SingletonComponent identity="src/Popover/popover/TippyPopoverStyles.tsx">
+    {React.useMemo(
+      () => (
+        <Global
+          styles={css({
+            "*[data-tippy-root]": {},
+            ".tippy-box": {
+              "&[data-theme=space-kit-list]": {
+                ...base.small,
+                boxShadow:
+                  "0 3px 4px 0 rgba(18, 21, 26, 0.04), 0 4px 8px 0 rgba(18, 21, 26, 0.08), 0 0 0 1px rgba(18, 21, 26, 0.08)",
+                backgroundColor: colors.white,
+                borderRadius: 4,
+                color: colors.black.base,
+                padding: 6,
+                margin: 2,
+                minWidth: 190,
 
-          ".tippy-content": {
-            padding: "0",
-          },
-        },
-      },
-    })}
-  />
+                ".tippy-content": {
+                  padding: "0",
+                },
+              },
+            },
+          })}
+        />
+      ),
+      [],
+    )}
+  </SingletonComponent>
 );

--- a/src/Select/SelectTests.story.tsx
+++ b/src/Select/SelectTests.story.tsx
@@ -43,7 +43,7 @@ storiesOf("Tests/Select", module)
       </div>
     ),
     {
-      chromatic: { delay: 200 },
+      chromatic: { delay: 2000 },
     },
   )
   .add(
@@ -82,6 +82,6 @@ storiesOf("Tests/Select", module)
       </div>
     ),
     {
-      chromatic: { delay: 200 },
+      chromatic: { delay: 2000 },
     },
   );

--- a/src/shared/components/SingletonComponent.spec.tsx
+++ b/src/shared/components/SingletonComponent.spec.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { SingletonComponent } from "./SingletonComponent";
+import { render, screen } from "@testing-library/react";
+import { SpaceKitProvider } from "../../SpaceKitProvider";
+
+it("when rendered without a provider, passed through content", () => {
+  const Component: React.FC = () => (
+    <SingletonComponent identity="test">
+      <div data-testid="element" />
+    </SingletonComponent>
+  );
+
+  render(
+    <>
+      <Component />
+      <Component />
+    </>,
+  );
+
+  expect(screen.getAllByTestId("element")).toHaveLength(2);
+});
+
+describe("with a provider", () => {
+  describe("given a single identity", () => {
+    it("given multiple elements, element renders only once", () => {
+      const Component: React.FC = () => (
+        <SingletonComponent identity="test">
+          <div data-testid="element" />
+        </SingletonComponent>
+      );
+
+      render(
+        <>
+          <SpaceKitProvider>
+            <Component />
+            <Component />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      expect(screen.getAllByTestId("element")).toHaveLength(1);
+    });
+
+    it("when two are rendered and then one is unmounted, renders one element still", () => {
+      const Component: React.FC = () => (
+        <SingletonComponent identity="test">
+          <div data-testid="element" />
+        </SingletonComponent>
+      );
+
+      const { rerender } = render(
+        <>
+          <SpaceKitProvider>
+            <Component />
+            <Component />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      const elementAfterFirstRender = screen.getByTestId("element");
+      expect(screen.getAllByTestId("element")).toHaveLength(1);
+
+      rerender(
+        <>
+          <SpaceKitProvider>
+            <Component />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      // There should be only one element and it should be the same element
+      // rendered the first time.
+      expect(screen.getAllByTestId("element")).toHaveLength(1);
+      expect(screen.getByTestId("element")).toBe(elementAfterFirstRender);
+    });
+
+    it("when rendered twice and then all are unmounted, renders nothing", () => {
+      const Component: React.FC = () => (
+        <SingletonComponent identity="test">
+          <div data-testid="element" />
+        </SingletonComponent>
+      );
+
+      const { rerender } = render(
+        <>
+          <SpaceKitProvider>
+            <Component />
+            <Component />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      expect(screen.getAllByTestId("element")).toHaveLength(1);
+
+      rerender(
+        <>
+          <SpaceKitProvider />
+        </>,
+      );
+
+      expect(screen.queryAllByTestId("element")).toHaveLength(0);
+    });
+  });
+
+  describe("given a multiple identities", () => {
+    const ComponentA: React.FC = () => (
+      <SingletonComponent identity="a">
+        <div data-testid="a" />
+      </SingletonComponent>
+    );
+
+    const ComponentB: React.FC = () => (
+      <SingletonComponent identity="b">
+        <div data-testid="b" />
+      </SingletonComponent>
+    );
+
+    it("given multiple elements, each element renders only once", () => {
+      render(
+        <>
+          <SpaceKitProvider>
+            <ComponentA />
+            <ComponentA />
+            <ComponentB />
+            <ComponentB />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.getAllByTestId("b")).toHaveLength(1);
+    });
+
+    it("when two are rendered and then one is unmounted, renders one element still", () => {
+      const { rerender } = render(
+        <>
+          <SpaceKitProvider>
+            <ComponentA />
+            <ComponentA />
+            <ComponentB />
+            <ComponentB />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.getAllByTestId("b")).toHaveLength(1);
+      const elementsAfterFirstRender = {
+        a: screen.getByTestId("a"),
+        b: screen.getByTestId("b"),
+      };
+
+      rerender(
+        <>
+          <SpaceKitProvider>
+            <ComponentA />
+            <ComponentB />
+          </SpaceKitProvider>
+        </>,
+      );
+
+      // There should be only one element and it should be the same element
+      // rendered the first time.
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.getAllByTestId("b")).toHaveLength(1);
+      expect(screen.getByTestId("a")).toBe(elementsAfterFirstRender.a);
+      expect(screen.getByTestId("b")).toBe(elementsAfterFirstRender.b);
+    });
+
+    it("when rendered twice and then all are unmounted, renders nothing", () => {
+      const { rerender } = render(
+        <SpaceKitProvider>
+          <ComponentA />
+          <ComponentA />
+          <ComponentB />
+          <ComponentB />
+        </SpaceKitProvider>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.getAllByTestId("b")).toHaveLength(1);
+
+      const elementsAfterFirstRender = {
+        a: screen.getByTestId("a"),
+        b: screen.getByTestId("b"),
+      };
+
+      rerender(
+        <SpaceKitProvider>
+          <ComponentA />
+          <ComponentA />
+          <ComponentB />
+        </SpaceKitProvider>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.getAllByTestId("b")).toHaveLength(1);
+      expect(screen.getByTestId("a")).toBe(elementsAfterFirstRender.a);
+      expect(screen.getByTestId("b")).toBe(elementsAfterFirstRender.b);
+
+      rerender(
+        <SpaceKitProvider>
+          <ComponentA />
+          <ComponentA />
+        </SpaceKitProvider>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.queryAllByTestId("b")).toHaveLength(0);
+      expect(screen.getByTestId("a")).toBe(elementsAfterFirstRender.a);
+
+      rerender(
+        <SpaceKitProvider>
+          <ComponentA />
+        </SpaceKitProvider>,
+      );
+
+      expect(screen.getAllByTestId("a")).toHaveLength(1);
+      expect(screen.queryAllByTestId("b")).toHaveLength(0);
+      expect(screen.getByTestId("a")).toBe(elementsAfterFirstRender.a);
+
+      rerender(<SpaceKitProvider></SpaceKitProvider>);
+
+      expect(screen.queryAllByTestId("a")).toHaveLength(0);
+      expect(screen.queryAllByTestId("b")).toHaveLength(0);
+    });
+  });
+});

--- a/src/shared/components/SingletonComponent.tsx
+++ b/src/shared/components/SingletonComponent.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  useHasSpaceKitProvider,
+  useSingletonComponent,
+} from "../../SpaceKitProvider";
+
+/**
+ * Indicates that we have already warned the user of needing a
+ * `SpaceKitProvider` once so we don't do it multiple times.
+ */
+let spaceKitProviderWarningIssued = false;
+
+/**
+ * Indicates that we have already warned the user of changing `children` on
+ * re-renders
+ */
+let childrenChangedWarningIssued = false;
+
+/**
+ * Component used to communicate with SpaceKitProvider to ensure that instances
+ * of this component rendered with the same `identity` will always result in a
+ * single element in the DOM.
+ *
+ * If there is no SpaceKitProvider, print a warning and passthrough the
+ * `children`
+ *
+ * This will assume that you don't actually care where the element is rendered
+ * in the DOM.
+ *
+ * All changes to `children` will be ignored. A warning will be logged if
+ * `children` changes. You should memoize `children` to avoid this warning.
+ */
+export const SingletonComponent: React.FC<{
+  children: ReturnType<React.FC>;
+  identity: string;
+}> = ({ children, identity }) => {
+  const hasSpaceKitProvider = useHasSpaceKitProvider();
+  const { show, hide } = useSingletonComponent();
+  const initialChildren = React.useRef(children);
+
+  React.useEffect(() => {
+    show({ identity, element: initialChildren.current });
+
+    return () => {
+      hide({ identity });
+    };
+  }, [initialChildren, hide, identity, show]);
+
+  if (!hasSpaceKitProvider && !spaceKitProviderWarningIssued) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "You must wrap your application with SpaceKitProvider to prevent repeated `<style />` tags being injected into the DOM.",
+    );
+    spaceKitProviderWarningIssued = true;
+  }
+
+  if (children !== initialChildren.current && !childrenChangedWarningIssued) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "All changes to `children` of `SingletonComponent` will be ignored. You should memoize the input.",
+    );
+    childrenChangedWarningIssued = true;
+  }
+
+  initialChildren.current = children;
+
+  return hasSpaceKitProvider ? null : children;
+};


### PR DESCRIPTION
Resolves issue AR-2148

We are rendering `<Global>` styles for all instances of `AbstractTooltip`, of which there can be thousands lying in wait on a single page. I incorrectly believed that these would be rendered just once to the DOM, but I was wrong; they are rendered once per instance rendered. This resulted in thousands of duplicated `<style>` tags being added.

## Release Notes

* Create an internal component called `SingletonComponent` (the name is poor and can be changed whenever we want because it's internal) that will take a string `identity` and only allow a single instance in the DOM regardless of how many times it's rendered. This requires us to use `SpaceKitProvider`. Tooltips can be used without `SpaceKitProvider` and will warn the user in the console.
* Wrap the two `<Global>` styles with the `SingletonComponent` to remove all excess DOM `<style />`s
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.17.4-canary.330.8834.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.17.4-canary.330.8834.0
  # or 
  yarn add @apollo/space-kit@8.17.4-canary.330.8834.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
