### PR TITLE
AR-2162 Add `as` prop to `Table` component

### DIFF
--- a/src/Table/Table.spec.tsx
+++ b/src/Table/Table.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Table } from "./Table";
 import { ClassNames } from "@emotion/core";
@@ -489,4 +489,26 @@ it("when passed `trAs` with a `body` and `head` with different additional classe
     expect(tr).not.toHaveClass("head-injected-class");
     expect(tr).toHaveStyleRule("color", "red");
   });
+});
+
+test("when passed an `as` prop, `className`s are merged", () => {
+  render(
+    <Table
+      as={<table className="test-class" data-testid="table" />}
+      data={[{ name: "Mason" }]}
+      keyOn="name"
+      columns={[
+        {
+          id: "name",
+          headerTitle: "Name",
+          render: ({ name }) => name,
+        },
+      ]}
+    />,
+  );
+
+  expect(screen.getByTestId("table")).toHaveClass("test-class");
+  expect(screen.getByTestId("table").classList.length).toBeGreaterThanOrEqual(
+    2,
+  );
 });

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -19,6 +19,16 @@ function createElementFromAs(as: As): React.ReactElement {
 
 interface Props<RowShape> {
   /**
+   * Override the the default element used to render the `table` element
+   *
+   * All props provided will be merged with props that this component adds,
+   * including `className`s being merged using emotion's `cx` function
+   *
+   * @default "<table />"
+   */
+  as?: React.ReactElement;
+
+  /**
    * Component data
    *
    * The shape of the data will be inferred from here
@@ -146,6 +156,7 @@ interface Props<RowShape> {
  * @see https://zpl.io/bAlrjJe
  */
 export function Table<RowShape>({
+  as = <table />,
   data,
   density = "standard",
   columns,
@@ -170,94 +181,105 @@ export function Table<RowShape>({
 
   return (
     <ClassNames>
-      {({ css, cx }) => (
-        <table
-          className={css({
-            borderCollapse: "collapse",
-            width: "100%",
-          })}
-        >
-          <colgroup>
-            {columns.map(({ colProps, id }) => (
-              <col key={id} {...colProps} />
-            ))}
-          </colgroup>
-
-          <thead>
-            {React.cloneElement(
-              headTrElement,
-              {
-                className: cx(
-                  css({
-                    ...typography.base.xsmall,
-                    borderBottom: `1px solid ${colors.silver.dark}`,
-                    color: colors.grey.darker,
-                    textAlign: "left",
-                    textTransform: "uppercase",
-                  }),
-                  headTrElement.props.className,
-                ),
-              },
-              ...columns.map(({ headerTitle, id, thAs = "th" }, colIndex) => {
-                const element = createElementFromAs(thAs);
-
-                return React.cloneElement(
-                  element,
-                  {
-                    className: css(
-                      css({
-                        fontWeight: 600,
-                        padding,
-                        paddingLeft: colIndex === 0 ? 0 : padding,
-                        paddingRight:
-                          colIndex === columns.length - 1 ? 0 : padding,
-                      }),
-                      element.props.className,
-                    ),
-                    key: id,
-                  },
-                  headerTitle,
-                );
+      {({ css, cx }) =>
+        React.cloneElement(
+          as,
+          {
+            className: cx(
+              css({
+                borderCollapse: "collapse",
+                width: "100%",
               }),
-            )}
-          </thead>
-          <tbody>
-            {data.map((item, index) =>
-              React.cloneElement(
-                bodyTrElement,
-                {
-                  key: getRowKey(item),
-                },
-                ...columns.map(({ as = "td", render, id }, colIndex) => {
-                  const element = createElementFromAs(as);
+              as.props.className,
+            ),
+          },
+          <>
+            <colgroup>
+              {columns.map(({ colProps, id }) => (
+                <col key={id} {...colProps} />
+              ))}
+            </colgroup>
 
-                  return React.cloneElement(
-                    element,
-                    {
-                      key: id,
-                      className: cx(
-                        css({
-                          // no border on the bottom row
-                          borderBottom:
-                            index === data.length - 1
-                              ? `none`
-                              : `1px solid ${colors.silver.dark}`,
-                          padding,
-                          paddingLeft: colIndex === 0 ? 0 : padding,
-                          paddingRight:
-                            colIndex === columns.length - 1 ? 0 : padding,
-                        }),
-                        element.props.className,
-                      ),
-                    },
-                    render(item, index, data),
-                  );
-                }),
-              ),
-            )}
-          </tbody>
-        </table>
-      )}
+            <thead>
+              {React.cloneElement(
+                headTrElement,
+                {
+                  className: cx(
+                    css({
+                      ...typography.base.xsmall,
+                      borderBottom: `1px solid ${colors.silver.dark}`,
+                      color: colors.grey.darker,
+                      textAlign: "left",
+                      textTransform: "uppercase",
+                    }),
+                    headTrElement.props.className,
+                  ),
+                },
+                <>
+                  {columns.map(({ headerTitle, id, thAs = "th" }, colIndex) => {
+                    const element = createElementFromAs(thAs);
+
+                    return React.cloneElement(
+                      element,
+                      {
+                        className: css(
+                          css({
+                            fontWeight: 600,
+                            padding,
+                            paddingLeft: colIndex === 0 ? 0 : padding,
+                            paddingRight:
+                              colIndex === columns.length - 1 ? 0 : padding,
+                          }),
+                          element.props.className,
+                        ),
+                        key: id,
+                      },
+                      headerTitle,
+                    );
+                  })}
+                </>,
+              )}
+            </thead>
+            <tbody>
+              {data.map((item, index) =>
+                React.cloneElement(
+                  bodyTrElement,
+                  {
+                    key: getRowKey(item),
+                  },
+                  <>
+                    {columns.map(({ as = "td", render, id }, colIndex) => {
+                      const element = createElementFromAs(as);
+
+                      return React.cloneElement(
+                        element,
+                        {
+                          key: id,
+                          className: cx(
+                            css({
+                              // no border on the bottom row
+                              borderBottom:
+                                index === data.length - 1
+                                  ? `none`
+                                  : `1px solid ${colors.silver.dark}`,
+                              padding,
+                              paddingLeft: colIndex === 0 ? 0 : padding,
+                              paddingRight:
+                                colIndex === columns.length - 1 ? 0 : padding,
+                            }),
+                            element.props.className,
+                          ),
+                        },
+                        render(item, index, data),
+                      );
+                    })}
+                  </>,
+                ),
+              )}
+            </tbody>
+          </>,
+        )
+      }
     </ClassNames>
   );
 }


### PR DESCRIPTION
Resolves AR-2162

Review this PR with [whitespace turned off](https://github.com/apollographql/space-kit/pull/333/files?diff=unified&w=1).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.17.5-canary.333.8909.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.17.5-canary.333.8909.0
  # or 
  yarn add @apollo/space-kit@8.17.5-canary.333.8909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
