### PR TITLE
Pass maxWidth to Popover in Select

### DIFF
--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -281,6 +281,7 @@ export const Select: React.FC<Props> = ({
   triggerAs = <Button />,
   truncate = true,
   value: valueProp,
+  maxWidth,
   ...props
 }) => {
   const {
@@ -597,6 +598,7 @@ export const Select: React.FC<Props> = ({
                 {renderTriggerNode(selectedItem)}
               </div>,
             )}
+            maxWidth={maxWidth}
           />
         )}
       </ClassNames>


### PR DESCRIPTION
The `maxWidth` type was being picked from `Popover` but wasn't being forwarded. This passing the value along so we can override the default 350px width
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.19.1-canary.334.8970.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.19.1-canary.334.8970.0
  # or 
  yarn add @apollo/space-kit@8.19.1-canary.334.8970.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
