### PR TITLE
update peer dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,8 +167,8 @@
   "peerDependencies": {
     "@emotion/cache": ">10.0.29",
     "@emotion/core": ">10.1.0",
-    "react": ">16",
-    "react-dom": ">16",
-    "framer-motion": ">1.6"
+    "framer-motion": ">=1.6",
+    "react": ">=16",
+    "react-dom": ">=16"
   }
 }


### PR DESCRIPTION
updating react dependencies from `>16` to `>=16` to match the version we use in other projects. `>16` will only match 17 and up.
![image](https://user-images.githubusercontent.com/3953093/114954608-fa4a8400-9e28-11eb-8613-086d00d94a10.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.20.1-canary.340.9080.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.20.1-canary.340.9080.0
  # or 
  yarn add @apollo/space-kit@8.20.1-canary.340.9080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
