### PR TITLE
Use onMouseDown instead of onClick for auto closing modals

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -194,7 +194,7 @@ export const Modal: React.FC<Props> = ({
         return React.cloneElement(
           containerAs,
           {
-            onClick: onClose,
+            onMouseDown: onClose,
             ...containerAs.props,
             className: cx(css(modalBackdrop), containerAs.props.className),
           },
@@ -211,6 +211,10 @@ export const Modal: React.FC<Props> = ({
                 mass: 0.2,
                 velocity: 8,
               },
+            }}
+            onMouseDown={(event: React.MouseEvent<unknown>) => {
+              event.stopPropagation();
+              as.props.onMouseDown?.(event);
             }}
             onClick={(event: React.MouseEvent<any>) => {
               event.stopPropagation();

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, css, ClassNames } from "@emotion/core";
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { motion, MotionProps } from "framer-motion";
 import * as typography from "../typography";
 import { colors } from "../colors";
@@ -140,6 +140,11 @@ export const Modal: React.FC<Props> = ({
   primaryAction,
   secondaryAction,
 }) => {
+  const mouseDownTarget = useRef<EventTarget | null>(null);
+  const onMouseDown = useCallback((e: MouseEvent) => {
+    mouseDownTarget.current = e.target;
+  }, []);
+
   const { disableAnimations } = useSpaceKitProvider();
 
   useEffect(() => {
@@ -194,7 +199,12 @@ export const Modal: React.FC<Props> = ({
         return React.cloneElement(
           containerAs,
           {
-            onMouseDown: onClose,
+            onMouseDown,
+            onClick: (event: MouseEvent) => {
+              if (mouseDownTarget.current === event.target) {
+                onClose?.();
+              }
+            },
             ...containerAs.props,
             className: cx(css(modalBackdrop), containerAs.props.className),
           },

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -140,9 +140,9 @@ export const Modal: React.FC<Props> = ({
   primaryAction,
   secondaryAction,
 }) => {
-  const mouseDownTarget = useRef<EventTarget | null>(null);
+  const backdropMouseDownTargetRef = useRef<EventTarget | null>(null);
   const onMouseDown = useCallback((e: MouseEvent) => {
-    mouseDownTarget.current = e.target;
+    backdropMouseDownTargetRef.current = e.target;
   }, []);
 
   const { disableAnimations } = useSpaceKitProvider();
@@ -201,7 +201,7 @@ export const Modal: React.FC<Props> = ({
           {
             onMouseDown,
             onClick: (event: MouseEvent) => {
-              if (mouseDownTarget.current === event.target) {
+              if (backdropMouseDownTargetRef.current === event.target) {
                 onClose?.();
               }
             },
@@ -221,10 +221,6 @@ export const Modal: React.FC<Props> = ({
                 mass: 0.2,
                 velocity: 8,
               },
-            }}
-            onMouseDown={(event: React.MouseEvent<unknown>) => {
-              event.stopPropagation();
-              as.props.onMouseDown?.(event);
             }}
             onClick={(event: React.MouseEvent<any>) => {
               event.stopPropagation();


### PR DESCRIPTION
This will prevent clicking in the modal and moving mouse outside from closing the modal
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.20.2-canary.342.9199.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.20.2-canary.342.9199.0
  # or 
  yarn add @apollo/space-kit@8.20.2-canary.342.9199.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
