### PR TITLE
Only remove ConfirmationTooltip timeout when unmounting

### DIFF
--- a/src/ConfirmationTooltip/index.tsx
+++ b/src/ConfirmationTooltip/index.tsx
@@ -30,7 +30,7 @@ export const ConfirmationTooltip: React.FC<Props> = ({
         window.clearTimeout(timeoutRef.current);
       }
     };
-  });
+  }, []);
 
   return (
     <AbstractTooltip


### PR DESCRIPTION
Right now this removes the timeout on all rerenders, which means if this gets rerendered between triggering and closing, it will get stuck open.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.20.3-canary.348.9290.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.20.3-canary.348.9290.0
  # or 
  yarn add @apollo/space-kit@8.20.3-canary.348.9290.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
