### PR TITLE
Backport of PR #340 update peer dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "typescript": "^3.9.2"
   },
   "peerDependencies": {
-    "react": ">16",
-    "framer-motion": ">1.6"
+    "react": ">=16",
+    "framer-motion": ">=1.6"
   }
 }


### PR DESCRIPTION
This is needed for gatsby-theme-apollo-core which isn't ready to take the major
version bumps.