### PR TITLE
Enable versionBranches, document backport releases

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -40,5 +40,6 @@
       "description": "Automatic PR created by renovate for dependency upgrades",
       "color": "yellow"
     }
-  ]
+  ],
+  "versionBranches": true
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^version-\d+$/
       - release:
           requires:
             - check-conflicting-icon-components
@@ -152,3 +153,4 @@ workflows:
             branches:
               only:
                 - main
+                - /^version-\d+$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1166,6 +1166,23 @@ _From #182_
 
 ---
 
+# v5.6.2 (Tue Jun 01 2021)
+
+#### 🚀 Enhancement
+
+- Backport (for `gatsby-theme-apollo-core`) of: update peer dependencies versions [#340](https://github.com/apollographql/space-kit/pull/340) ([@Jephuff](https://github.com/Jephuff))
+
+
+---
+
+# v5.6.1 (Tue Jun 01 2021)
+
+#### 🚀 Enhancement
+
+Accidentaly release from trying to create 5.6.2.
+
+---
+
 # v5.6.0 (Fri Jun 12 2020)
 
 #### 🚀 Enhancement


### PR DESCRIPTION
Note that it's not clear if the `version-5` I made will actually work (I ended up releasing 5.6.1 manually) but hopefully this will make us happy once we move to v9 and it creates `version-9` for us.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.21.1-canary.351.9360.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@8.21.1-canary.351.9360.0
  # or 
  yarn add @apollo/space-kit@8.21.1-canary.351.9360.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
