### PR TITLE
make alert card x optional

### DIFF
--- a/src/AlertCard/AlertCard.story.mdx
+++ b/src/AlertCard/AlertCard.story.mdx
@@ -172,6 +172,28 @@ Success alerts are confirmation that the action the user was trying to take has 
   </Story>
 </Canvas>
 
+## Without 'x'
+
+Success alerts are confirmation that the action the user was trying to take has succeeded.
+
+<Canvas>
+  <Story name="without x light">
+    <AlertCard closeable={false} type="success" heading="Success alert">
+      A new schema registry has been created by timbotnik.
+    </AlertCard>
+  </Story>
+  <Story name="without x dark">
+    <AlertCard
+      closeable={false}
+      type="success"
+      theme="dark"
+      heading="Success alert"
+    >
+      A new schema registry has been created by timbotnik.
+    </AlertCard>
+  </Story>
+</Canvas>
+
 ## Props
 
 ### `Alert`

--- a/src/AlertCard/AlertCard.story.mdx
+++ b/src/AlertCard/AlertCard.story.mdx
@@ -178,13 +178,13 @@ Success alerts are confirmation that the action the user was trying to take has 
 
 <Canvas>
   <Story name="without x light">
-    <AlertCard closeable={false} type="success" heading="Success alert">
+    <AlertCard dismissable={false} type="success" heading="Success alert">
       A new schema registry has been created by timbotnik.
     </AlertCard>
   </Story>
   <Story name="without x dark">
     <AlertCard
-      closeable={false}
+      dismissable={false}
       type="success"
       theme="dark"
       heading="Success alert"

--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -62,6 +62,12 @@ interface AlertCardProps {
   onClose: () => void;
 
   /**
+   * whether or not to include the 'x' button
+   * which calls 'onClose'
+   */
+  closeable: boolean;
+
+  /**
    * layout for longer content
    *
    * @default false
@@ -81,6 +87,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
   as = "section",
   heading,
   onClose,
+  closeable = true,
   actions,
   headingAs = "h2",
   children,
@@ -202,41 +209,43 @@ export const AlertCard: React.FC<AlertCardProps> = ({
                     : React.createElement(headingAs, headingProps);
                 }}
               </ClassNames>
-              <Button
-                onClick={onClose}
-                size="small"
-                feel="flat"
-                theme={theme}
-                css={{
-                  marginRight: -9,
-                  marginTop: -9,
-                  color:
-                    theme === "light"
-                      ? colors.grey.lighter
-                      : colors.midnight.lighter,
-                  ":hover": {
-                    backgroundColor: "transparent",
+              {closeable && (
+                <Button
+                  onClick={onClose}
+                  size="small"
+                  feel="flat"
+                  theme={theme}
+                  css={{
+                    marginRight: -9,
+                    marginTop: -9,
                     color:
                       theme === "light"
-                        ? colors.grey.light
-                        : colors.midnight.lightest,
-                  },
-                }}
-                color={
-                  {
-                    light: colors.grey.lighter,
-                    dark: colors.midnight.lighter,
-                  }[theme]
-                }
-                icon={
-                  <IconClose
-                    css={{
-                      width: 10,
-                      height: 10,
-                    }}
-                  />
-                }
-              />
+                        ? colors.grey.lighter
+                        : colors.midnight.lighter,
+                    ":hover": {
+                      backgroundColor: "transparent",
+                      color:
+                        theme === "light"
+                          ? colors.grey.light
+                          : colors.midnight.lightest,
+                    },
+                  }}
+                  color={
+                    {
+                      light: colors.grey.lighter,
+                      dark: colors.midnight.lighter,
+                    }[theme]
+                  }
+                  icon={
+                    <IconClose
+                      css={{
+                        width: 10,
+                        height: 10,
+                      }}
+                    />
+                  }
+                />
+              )}
             </div>
 
             {extended && (

--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -65,7 +65,7 @@ interface AlertCardProps {
    * whether or not to include the 'x' button
    * which calls 'onClose'
    */
-  closeable: boolean;
+  dismissable: boolean;
 
   /**
    * layout for longer content
@@ -87,7 +87,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
   as = "section",
   heading,
   onClose,
-  closeable = true,
+  dismissable = true,
   actions,
   headingAs = "h2",
   children,
@@ -209,7 +209,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
                     : React.createElement(headingAs, headingProps);
                 }}
               </ClassNames>
-              {closeable && (
+              {dismissable && (
                 <Button
                   onClick={onClose}
                   size="small"


### PR DESCRIPTION
We use the AlertCard in our Toasts & for our GDPR cookie toast, we don't want to give the option to dismiss the cookie toast. Lets be able to remove the 'x' in the Alert Card.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.2.1-canary.360.9607.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.2.1-canary.360.9607.0
  # or 
  yarn add @apollo/space-kit@9.2.1-canary.360.9607.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
