### PR TITLE
Handle no table header specified case

### DIFF
--- a/src/Table/Table.stories.mdx
+++ b/src/Table/Table.stories.mdx
@@ -51,6 +51,7 @@ Table density is an important characteristic when considering how to present inf
         columns={[
           {
             id: "image",
+            headerTitle: "img",
             render: ({ image }) => (
               <img style={{ width: 24, height: 24 }} src={image} />
             ),
@@ -316,6 +317,101 @@ Table density is an important characteristic when considering how to present inf
           {
             id: "name",
             headerTitle: "name",
+            render: ({ name }) => <>{name}</>,
+          },
+        ]}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+### no table headers
+
+<Canvas>
+  <Story name="no headers light">
+    <div style={{ padding: 16 }}>
+      <Table
+        keyOn="name"
+        data={[
+          {
+            name: "Alice Howell",
+            image: require("./table.stories/alice-howell.png"),
+          },
+          {
+            name: "Benjamin Lawrence",
+            image: require("./table.stories/benjamin-lawrence.png"),
+          },
+          {
+            name: "Cynthia Bowman",
+            image: require("./table.stories/cynthia-bowman.png"),
+          },
+          {
+            name: "Jeremy Jacobs",
+            image: require("./table.stories/jeremy-jacobs.png"),
+          },
+          {
+            name: "Jeremy Griffin",
+            image: require("./table.stories/jeremy-griffin.png"),
+          },
+        ]}
+        columns={[
+          {
+            id: "image",
+            render: ({ image }) => (
+              <img style={{ width: 24, height: 24 }} src={image} />
+            ),
+          },
+          {
+            id: "name",
+            render: ({ name }) => <>{name}</>,
+          },
+        ]}
+      />
+    </div>
+  </Story>
+  <Story name="no headers dark">
+    <div
+      style={{
+        background: colors.black.base,
+        borderRadius: 8,
+        padding: 16,
+        color: colors.white,
+      }}
+    >
+      <Table
+        theme="dark"
+        keyOn="name"
+        data={[
+          {
+            name: "Alice Howell",
+            image: require("./table.stories/alice-howell.png"),
+          },
+          {
+            name: "Benjamin Lawrence",
+            image: require("./table.stories/benjamin-lawrence.png"),
+          },
+          {
+            name: "Cynthia Bowman",
+            image: require("./table.stories/cynthia-bowman.png"),
+          },
+          {
+            name: "Jeremy Jacobs",
+            image: require("./table.stories/jeremy-jacobs.png"),
+          },
+          {
+            name: "Jeremy Griffin",
+            image: require("./table.stories/jeremy-griffin.png"),
+          },
+        ]}
+        columns={[
+          {
+            id: "image",
+            render: ({ image }) => (
+              <img style={{ width: 24, height: 24 }} src={image} />
+            ),
+          },
+          {
+            id: "name",
             render: ({ name }) => <>{name}</>,
           },
         ]}

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -225,52 +225,56 @@ export function Table<RowShape>({
               ))}
             </colgroup>
 
-            <thead>
-              {React.cloneElement(
-                headTrElement,
-                {
-                  className: cx(
-                    css({
-                      ...typography.base.xsmall,
-                      borderBottom: border,
-                      borderTop: border,
-                      color:
-                        theme === "light"
-                          ? colors.grey.base
-                          : theme === "dark"
-                          ? colors.midnight.lighter
-                          : assertUnreachable(theme),
-                      textAlign: "left",
-                      textTransform: "uppercase",
-                    }),
-                    headTrElement.props.className,
-                  ),
-                },
-                <>
-                  {columns.map(({ headerTitle, id, thAs = "th" }, colIndex) => {
-                    const element = createElementFromAs(thAs);
+            {columns.filter((c) => c.headerTitle).length > 0 && (
+              <thead>
+                {React.cloneElement(
+                  headTrElement,
+                  {
+                    className: cx(
+                      css({
+                        ...typography.base.xsmall,
+                        borderBottom: border,
+                        borderTop: border,
+                        color:
+                          theme === "light"
+                            ? colors.grey.base
+                            : theme === "dark"
+                            ? colors.midnight.lighter
+                            : assertUnreachable(theme),
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }),
+                      headTrElement.props.className,
+                    ),
+                  },
+                  <>
+                    {columns.map(
+                      ({ headerTitle, id, thAs = "th" }, colIndex) => {
+                        const element = createElementFromAs(thAs);
 
-                    return React.cloneElement(
-                      element,
-                      {
-                        className: css(
-                          css({
-                            fontWeight: 600,
-                            padding,
-                            paddingLeft: colIndex === 0 ? 0 : padding,
-                            paddingRight:
-                              colIndex === columns.length - 1 ? 0 : padding,
-                          }),
-                          element.props.className,
-                        ),
-                        key: id,
+                        return React.cloneElement(
+                          element,
+                          {
+                            className: css(
+                              css({
+                                fontWeight: 600,
+                                padding,
+                                paddingLeft: colIndex === 0 ? 0 : padding,
+                                paddingRight:
+                                  colIndex === columns.length - 1 ? 0 : padding,
+                              }),
+                              element.props.className,
+                            ),
+                            key: id,
+                          },
+                          headerTitle,
+                        );
                       },
-                      headerTitle,
-                    );
-                  })}
-                </>,
-              )}
-            </thead>
+                    )}
+                  </>,
+                )}
+              </thead>
+            )}
             <tbody>
               {data.map((item, index) =>
                 React.cloneElement(


### PR DESCRIPTION
hide table header (double borders) if there are no headers specified in columns
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.4.1-canary.371.9780.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.4.1-canary.371.9780.0
  # or 
  yarn add @apollo/space-kit@9.4.1-canary.371.9780.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
