### PR TITLE
Fix border color in dark mode for AlertCard

### DIFF
--- a/src/AlertCard/AlertCard.tsx
+++ b/src/AlertCard/AlertCard.tsx
@@ -143,7 +143,12 @@ export const AlertCard: React.FC<AlertCardProps> = ({
                 borderStyle: "solid",
                 borderRadius: 4,
                 borderWidth: 1,
-                borderColor: colors.silver.dark,
+                borderColor:
+                  theme === "light"
+                    ? colors.silver.dark
+                    : theme === "dark"
+                    ? colors.midnight.dark
+                    : assertUnreachable(theme),
                 padding: 15,
               }),
               otherProps.className,


### PR DESCRIPTION
this one slipped through by accident last week when i added a border to the AlertCard but didn't set the dark mode color properly

it has made the border color of the CORS card in sandbox silver unfortunately

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.6.0-canary.372.9811.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.6.0-canary.372.9811.0
  # or 
  yarn add @apollo/space-kit@9.6.0-canary.372.9811.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
