### PR TITLE
Modal: no title, no description dont render extra margin-top

### DIFF
--- a/src/Modal/Modal.story.tsx
+++ b/src/Modal/Modal.story.tsx
@@ -302,4 +302,27 @@ storiesOf("Modal", module)
           .join(" ")}
       </div>
     </Modal>
+  ))
+  .add("No title and no description", () => (
+    <Modal
+      size="medium"
+      verticalScrollMode="children"
+      primaryAction={
+        <Button color={colors.green.base} style={{ color: colors.white }}>
+          Buy 1 Seat
+        </Button>
+      }
+      secondaryAction={<Button color={colors.white}>Cancel</Button>}
+      bottomLeftText={
+        <span style={{ color: colors.blue.base }}>
+          Update Billing Information
+        </span>
+      }
+    >
+      <div>
+        {Array.from(Array(500))
+          .map(() => "lorem ipsum dolor")
+          .join(" ")}
+      </div>
+    </Modal>
   ));

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -82,7 +82,7 @@ interface Props {
   /**
    * Title of the modal
    */
-  title: React.ReactNode;
+  title?: React.ReactNode;
 }
 
 const modalBackdrop = css`
@@ -285,10 +285,11 @@ export const Modal: React.FC<Props> = ({
             </div>
             <div
               css={css(
-                {
-                  marginTop:
-                    size === "large" ? 24 : size === "medium" ? 16 : 12,
-                },
+                title &&
+                  description && {
+                    marginTop:
+                      size === "large" ? 24 : size === "medium" ? 16 : 12,
+                  },
                 verticalScrollMode === "children" && {
                   overflowY: "auto",
                 },


### PR DESCRIPTION
For https://github.com/mdg-private/studio-ui/pull/4669, a modal with no title and no description does not need the `margin-top` added to space the content from the title and description.

## Before
<img width="819" alt="Screen Shot 2021-08-23 at 4 50 29 PM" src="https://user-images.githubusercontent.com/1314446/130517686-43496c79-b058-4714-ab0d-22a06bf18f1f.png">

## After
<img width="710" alt="Screen Shot 2021-08-23 at 4 50 41 PM" src="https://user-images.githubusercontent.com/1314446/130517700-7bfdde92-be34-4cb9-9ae5-ac0cff305160.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.6.1-canary.373.9851.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.6.1-canary.373.9851.0
  # or 
  yarn add @apollo/space-kit@9.6.1-canary.373.9851.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
