### PR TITLE
modal - should be no title OR description on top margin

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -285,11 +285,10 @@ export const Modal: React.FC<Props> = ({
             </div>
             <div
               css={css(
-                title &&
-                  description && {
-                    marginTop:
-                      size === "large" ? 24 : size === "medium" ? 16 : 12,
-                  },
+                (title || description) && {
+                  marginTop:
+                    size === "large" ? 24 : size === "medium" ? 16 : 12,
+                },
                 verticalScrollMode === "children" && {
                   overflowY: "auto",
                 },


### PR DESCRIPTION
I made a mistake in https://github.com/apollographql/space-kit/pull/373, instead of not having a top margin between the content if there's no title and no description, it should be no title OR no description. The mistake's effect can see in this chromatic https://www.chromatic.com/test?appId=5a77a6d38a9e3c002045d20d&id=61255022235bb7003aae37f0

before
![image](https://user-images.githubusercontent.com/1314446/130691039-7c7defad-e31e-4d9f-b4ad-66dc7b69d8b9.png)

after
<img width="1113" alt="Screen Shot 2021-08-24 at 5 16 41 PM" src="https://user-images.githubusercontent.com/1314446/130691200-599a3aac-6cca-425e-828c-ced159a555f6.png">
