### PR TITLE
allow ConfirmationTooltip to have an initial tip

### DIFF
--- a/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
+++ b/src/ConfirmationTooltip/ConfirmationTooltip.story.tsx
@@ -50,10 +50,10 @@ storiesOf("ConfirmationTooltip", module)
       chromatic: { delay: 500 },
     },
   )
-  .add("interactive", () => {
+  .add("interactive, with inital content on hover before click", () => {
     return (
       <div style={{ padding: 50 }}>
-        <ConfirmationTooltip content="default content">
+        <ConfirmationTooltip content="default content" initalContent="hello">
           <Button>click</Button>
         </ConfirmationTooltip>
       </div>

--- a/src/ConfirmationTooltip/index.tsx
+++ b/src/ConfirmationTooltip/index.tsx
@@ -6,7 +6,9 @@ type Props = Pick<
   React.ComponentProps<typeof AbstractTooltip>,
   "children" | "content" | "disabled"
 > &
-  AbstractTooltipProps;
+  AbstractTooltipProps & {
+    initalContent?: string;
+  };
 
 /**
  * Display a non-interactive tooltip after an element is clicked on and then
@@ -14,6 +16,8 @@ type Props = Pick<
  */
 export const ConfirmationTooltip: React.FC<Props> = ({
   children,
+  initalContent,
+  content,
   ...props
 }) => {
   /**
@@ -32,28 +36,39 @@ export const ConfirmationTooltip: React.FC<Props> = ({
     };
   }, []);
 
+  const [displayedContent, setDisplayedContent] = React.useState(
+    initalContent ?? content,
+  );
+
   return (
-    <AbstractTooltip
-      trigger="click"
-      {...props}
-      onShow={(instance) => {
-        if (timeoutRef.current) {
-          window.clearTimeout(timeoutRef.current);
-        }
-
-        timeoutRef.current = window.setTimeout(() => {
-          instance.hide();
-        }, 3000);
-      }}
-      onHide={() => {
-        if (timeoutRef.current) {
-          window.clearTimeout(timeoutRef.current);
-        }
-
-        timeoutRef.current = null;
+    <div
+      onClick={() => {
+        setDisplayedContent(content);
       }}
     >
-      {children}
-    </AbstractTooltip>
+      <AbstractTooltip
+        trigger={displayedContent === initalContent ? "mouseenter" : "click"}
+        {...props}
+        content={displayedContent}
+        onShow={(instance) => {
+          if (timeoutRef.current) {
+            window.clearTimeout(timeoutRef.current);
+          }
+
+          timeoutRef.current = window.setTimeout(() => {
+            instance.hide();
+          }, 3000);
+        }}
+        onHide={() => {
+          if (timeoutRef.current) {
+            window.clearTimeout(timeoutRef.current);
+          }
+          setDisplayedContent(initalContent);
+          timeoutRef.current = null;
+        }}
+      >
+        {children}
+      </AbstractTooltip>
+    </div>
   );
 };


### PR DESCRIPTION
This is to allow for @jglovier's request in https://github.com/mdg-private/studio-ui/pull/4813#discussion_r697719047 to allow for the confirmation tooltip to show an initial message "Copy to clipboard" on hover before the "Copied" tip on click.

Currently `Tooltip` and `ConfirmationTooltip` overwrite each other, the inner most nested tip will take effect, and the outer one will have no effect. So I've attempted to allow for this behaviour by adding an `initialContent` prop to `ConfirmationTooltip`. Onclick, the displayed content switches to the default content, on hide it switches back to initial content. This works well, except for a split second when the tip is hiding the initial text can be seen again. Setting another timeout before doing `setDisplayedContent(initalContent);` in `onHide` doesn't seem to work. Anyone have an idea on how to solve this? 😖

![CPT2108301236-254x143](https://user-images.githubusercontent.com/1314446/131373619-7faf08c3-dab1-454d-b0eb-8613b381cba7.gif)

