### PR TITLE
Modal: add xlarge size

### DIFF
--- a/src/Modal/Modal.story.tsx
+++ b/src/Modal/Modal.story.tsx
@@ -9,7 +9,7 @@ import { Button } from "../Button";
 interface Props {
   title: string;
   description: string;
-  size: "small" | "medium" | "large";
+  size: "small" | "medium" | "large" | "xlarge";
 }
 
 const CustomComponent = React.forwardRef<HTMLDivElement, { an?: undefined }>(
@@ -83,6 +83,11 @@ storiesOf("Modal", module)
         title="Modal Title"
         description="modal description"
         size={"large"}
+      />
+      <ModalStory
+        title="Modal Title"
+        description="modal description"
+        size={"xlarge"}
       />
     </div>
   ))
@@ -279,7 +284,7 @@ storiesOf("Modal", module)
       </div>
     </Modal>
   ))
-  .add("using verticalScrollMode 'children'", () => (
+  .add("using verticalScrollMode 'children' (medium)", () => (
     <Modal
       size="medium"
       title="Modal Title"

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -77,7 +77,7 @@ interface Props {
   /**
    * Size to show the modal at
    */
-  size: "small" | "medium" | "large";
+  size: "small" | "medium" | "large" | "xlarge";
 
   /**
    * Title of the modal
@@ -120,6 +120,8 @@ function getModalWidth(size: Props["size"]): Property.Width<TLength> {
       return 600;
     case "large":
       return 800;
+    case "xlarge":
+      return 1048;
     /* istanbul ignore next */
     default:
       throw assertUnreachable(size);
@@ -237,7 +239,8 @@ export const Modal: React.FC<Props> = ({
                   minWidth: 400,
                   opacity: 1,
                   overflowY: verticalScrollMode === "modal" ? "auto" : "hidden",
-                  padding: size === "large" ? "40px" : "32px",
+                  padding:
+                    size === "large" || size === "xlarge" ? "40px" : "32px",
                   position: "absolute",
                   width: getModalWidth(size),
                   zIndex: 11,
@@ -287,7 +290,11 @@ export const Modal: React.FC<Props> = ({
               css={css(
                 (title || description) && {
                   marginTop:
-                    size === "large" ? 24 : size === "medium" ? 16 : 12,
+                    size === "large" || size === "xlarge"
+                      ? 24
+                      : size === "medium"
+                      ? 16
+                      : 12,
                 },
                 verticalScrollMode === "children" && {
                   overflowY: "auto",


### PR DESCRIPTION
For https://github.com/mdg-private/studio-ui/pull/4920, an xlarge modal that is 1048px wide 

<img width="1184" alt="Screen Shot 2021-09-10 at 3 58 26 PM" src="https://user-images.githubusercontent.com/1314446/132910658-99e270d1-186f-40d7-b03b-9833b25c11ae.png">
for a better readme editing experience


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.6.3-canary.376.9919.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.6.3-canary.376.9919.0
  # or 
  yarn add @apollo/space-kit@9.6.3-canary.376.9919.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
