### PR TITLE
Add a red asterisk to required FormLabels

### DIFF
--- a/src/FormControl/FormControl.spec.tsx
+++ b/src/FormControl/FormControl.spec.tsx
@@ -23,6 +23,17 @@ test("when passed a label, renders it", () => {
   expect(screen.getByText("label text")).toBeInTheDocument();
 });
 
+test("when passed a required label, renders the red asterisk", () => {
+  render(
+    <FormControl id="test">
+      <FormLabel required={true}>label text</FormLabel>
+      <Input />
+    </FormControl>,
+  );
+
+  expect(screen.getByText("*")).toBeInTheDocument();
+});
+
 test("when the label is clicked it focuses the input", () => {
   const labelText = "label text";
   const { container } = render(

--- a/src/FormControl/FormControls.stories.mdx
+++ b/src/FormControl/FormControls.stories.mdx
@@ -199,6 +199,20 @@ If you render a `FormErrorMessage` then any `FormHelperText` will not be rendere
   </Story>
 </Canvas>
 
+## Required labels
+
+You can pass `required={true}` to your `FormLabel` to add a red asterisk.
+
+<Canvas>
+  <Story name="Required labels">
+    <FormControl id="required-labels">
+      <FormLabel required={true}>Input Label</FormLabel>
+      <FormDescription>This component has helper text.</FormDescription>
+      <Input placeholder="Input Label" />
+    </FormControl>
+  </Story>
+</Canvas>
+
 ## Adornments
 
 You can use `FormStartAdornment` and/or `FormEndAdornment` components to add content to the beginning or end of the element

--- a/src/FormLabel/index.tsx
+++ b/src/FormLabel/index.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as typography from "../typography";
 import { css, jsx } from "@emotion/core";
 import { useFormControlInternalContext } from "../shared/FormControlContext";
+import { colors } from "../colors";
 
 interface Props
   extends Pick<
@@ -14,6 +15,7 @@ interface Props
     "aria-invalid" | "className" | "style" | "id" | "htmlFor"
   > {
   children: React.ReactNode;
+  required?: boolean;
 }
 
 /**
@@ -26,6 +28,7 @@ interface Props
 export const FormLabel: React.FC<Props> = ({
   "aria-invalid": ariaInvalid,
   children,
+  required,
   className,
   htmlFor,
   id,
@@ -55,6 +58,7 @@ export const FormLabel: React.FC<Props> = ({
         })}
       >
         {children}
+        {required && <span css={{ color: colors.red.base }}>*</span>}
       </label>
     ),
     [
@@ -64,6 +68,7 @@ export const FormLabel: React.FC<Props> = ({
       description,
       errorMessageElement,
       htmlFor,
+      required,
       id,
       inputId,
       labelId,


### PR DESCRIPTION
https://www.figma.com/file/DvMTYJsZozsncPDvj3CKw4/Graph-README?node-id=164%3A3692

![image](https://user-images.githubusercontent.com/14367451/133494700-11dc8dbf-fe3e-4e72-a993-0e1a80fa7a1c.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.7.1-canary.377.9934.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @apollo/space-kit@9.7.1-canary.377.9934.0
  # or 
  yarn add @apollo/space-kit@9.7.1-canary.377.9934.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
