### PR TITLE
Update tooltips to support controlled visibility

### DIFF
--- a/src/AbstractTooltip/index.tsx
+++ b/src/AbstractTooltip/index.tsx
@@ -38,7 +38,9 @@ export interface AbstractTooltipProps {
   matchTriggerWidth?: boolean;
 }
 
-type Props = TippyProps & AbstractTooltipProps;
+type Props = TippyProps &
+  AbstractTooltipProps &
+  ({ visible?: undefined } | { visible: boolean; trigger?: undefined });
 
 export const AbstractTooltip: React.FC<Props> = ({
   animation = "shift-away",
@@ -51,6 +53,7 @@ export const AbstractTooltip: React.FC<Props> = ({
   hideOnClick,
   matchTriggerWidth = false,
   popperOptions = {},
+  visible,
   ...props
 }) => {
   const {
@@ -67,7 +70,7 @@ export const AbstractTooltip: React.FC<Props> = ({
         arrow={false}
         hideOnClick={forceVisibleForTestingOnly ? false : hideOnClick}
         trigger={forceVisibleForTestingOnly ? "manual" : trigger}
-        visible={forceVisibleForTestingOnly ? true : undefined}
+        visible={forceVisibleForTestingOnly ? true : visible}
         theme="space-kit"
         popperOptions={{
           ...popperOptions,

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -11,6 +11,7 @@ type Props = Pick<
   | "disabled"
   | "interactive"
   | "placement"
+  | "visible"
 > &
   AbstractTooltipProps;
 
@@ -21,13 +22,15 @@ type Props = Pick<
  * delay when hovering on an element. We also wait for the user's cursor to rest
  * on the element; meaning we won't show a Tooltip while the cursor is moving
  */
-export const Tooltip: React.FC<Props> = ({ children, ...props }) => {
+export const Tooltip: React.FC<Props> = ({ children, visible, ...props }) => {
   return (
     <TooltipContextProvider descendsFromTooltip>
       <AbstractTooltip
         delay={150}
-        trigger="mouseenter"
         plugins={[mouseRest]}
+        {...(typeof visible === "boolean"
+          ? { visible }
+          : { trigger: "mouseenter" })}
         {...props}
       >
         {children}


### PR DESCRIPTION
Right now we do have `forceVisibleForTestingOnly` which does work if you want to make a tooltip always visible, but it creates a bunch of errors, doesn't work to keep it closed and of course the name implies you shouldn't use it. This adds official support for the `visible` prop so we can have fully controlled tooltips