### PR TITLE
Source code icon

### DIFF
--- a/src/icons/svgs/essentials/icon-code.svg
+++ b/src/icons/svgs/essentials/icon-code.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m6 7-5 5.185L6 17M14 3l-4 18M18 7l5 5.185L18 17" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
This PR adds a new icon for source code. It is different than the [code block icon](http://localhost:6006/?path=/story/components-icons--icon-codeblock) (which is intended to represent formatting of content in UI situations with multiple formatting options), and it is different than the [operations icon](http://localhost:6006/?path=/story/components-icons--icon-operations) which is more suited to represent JS based code specifically, or GraphQL operations (due to the curly brackets). This one is the ubiquitous icon for "source code", something we can use in a few different places like embed modals, non-GitHub repository links, etc.

![image](https://user-images.githubusercontent.com/1319791/138777523-3e8c74dc-5bb6-494a-bc82-945487847fee.png)

Note: this is hand made, not from Streamline.